### PR TITLE
Add xUnit tests for combat rolls

### DIFF
--- a/CloudDragon.Tests/CloudDragon.Tests.csproj
+++ b/CloudDragon.Tests/CloudDragon.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CloudDragon\CloudDragon.csproj" />
+  </ItemGroup>
+</Project>

--- a/CloudDragon.Tests/CombatRollServiceTests.cs
+++ b/CloudDragon.Tests/CombatRollServiceTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Xunit;
+using CloudDragonApi.Services;
+using CloudDragonLib.Models;
+using System.Collections.Generic;
+
+namespace CloudDragon.Tests
+{
+    public class CombatRollServiceTests
+    {
+        [Fact]
+        public void RollD20_returns_value_between_1_and_20()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                int roll = CombatRollService.RollD20();
+                Assert.InRange(roll, 1, 20);
+            }
+        }
+
+        [Fact]
+        public void RollSavingThrow_applies_modifier_and_checks_range()
+        {
+            var character = new Character
+            {
+                Stats = new Dictionary<string, int>
+                {
+                    { "Strength", 15 }
+                }
+            };
+
+            var (roll, total, success) = CombatRollService.RollSavingThrow(character, "Strength", 12);
+
+            Assert.InRange(roll, 1, 20);
+            int expectedModifier = (int)Math.Floor((15 - 10) / 2.0);
+            Assert.Equal(roll + expectedModifier, total);
+            Assert.Equal(total >= 12, success);
+        }
+
+        [Fact]
+        public void RollDamage_returns_value_within_expected_range()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                int result = CombatRollService.RollDamage("2d6");
+                Assert.InRange(result, 2, 12);
+            }
+        }
+    }
+}

--- a/CloudDragonLib/CloudDragonLib.sln
+++ b/CloudDragonLib/CloudDragonLib.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudDragonLib", "CloudDrag
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudDragon", "..\CloudDragon\CloudDragon.csproj", "{7098CF1C-AAA5-4A47-9F76-960BF334576D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CloudDragon.Tests", "..\CloudDragon.Tests\CloudDragon.Tests.csproj", "{3669C13A-7E42-4CF0-8970-56D4E33CA536}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +22,12 @@ Global
 		{7098CF1C-AAA5-4A47-9F76-960BF334576D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7098CF1C-AAA5-4A47-9F76-960BF334576D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7098CF1C-AAA5-4A47-9F76-960BF334576D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7098CF1C-AAA5-4A47-9F76-960BF334576D}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {7098CF1C-AAA5-4A47-9F76-960BF334576D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {3669C13A-7E42-4CF0-8970-56D4E33CA536}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {3669C13A-7E42-4CF0-8970-56D4E33CA536}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {3669C13A-7E42-4CF0-8970-56D4E33CA536}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {3669C13A-7E42-4CF0-8970-56D4E33CA536}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ Things it can be used for:
 
 
 <h3 align="left">Special Thanks</h3>
+
+### Running Tests
+
+Ensure the [.NET SDK](https://dotnet.microsoft.com/download) is installed.
+From the repository root execute:
+
+```bash
+dotnet test CloudDragonLib/CloudDragonLib.sln
+```
+
+This command builds the solution and runs all unit tests including `CloudDragon.Tests`.
+


### PR DESCRIPTION
## Summary
- add new xUnit test project **CloudDragon.Tests**
- cover `RollD20`, `RollSavingThrow`, and `RollDamage`
- include test project in `CloudDragonLib.sln`
- document how to run tests in README

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840670f07fc832aa77b6755cf578f71