### PR TITLE
Add debug logging across API

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/CombatRollService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/CombatRollService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using CharacterModel = CloudDragonLib.Models.Character;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi.Services
 {
@@ -10,7 +11,9 @@ namespace CloudDragonApi.Services
 
         public static int RollD20()
         {
-            return rng.Next(1, 21);
+            int roll = rng.Next(1, 21);
+            DebugLogger.Log($"Rolled d20: {roll}");
+            return roll;
         }
 
         public static (int roll, int total, bool success) RollSavingThrow(CharacterModel target, string ability, int dc)
@@ -24,6 +27,7 @@ namespace CloudDragonApi.Services
             int roll = RollD20();
             int total = roll + modifier;
             bool success = total >= dc;
+            DebugLogger.Log($"Saving throw for {ability}: roll={roll}, modifier={modifier}, total={total}, dc={dc}, success={success}");
 
             return (roll, total, success);
         }
@@ -33,6 +37,7 @@ namespace CloudDragonApi.Services
             int roll = RollD20();
             int total = roll + attackModifier;
             bool hit = total >= targetAC;
+            DebugLogger.Log($"Attack roll: roll={roll}, attackModifier={attackModifier}, total={total}, targetAC={targetAC}, hit={hit}");
 
             return (roll, total, hit);
         }
@@ -48,7 +53,13 @@ namespace CloudDragonApi.Services
 
             int total = 0;
             for (int i = 0; i < numDice; i++)
-                total += rng.Next(1, dieSize + 1);
+            {
+                int part = rng.Next(1, dieSize + 1);
+                total += part;
+                DebugLogger.Log($"Damage dice {i + 1}/{numDice}: {part}");
+            }
+
+            DebugLogger.Log($"Total damage for {damageDice}: {total}");
 
             return total;
         }

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragonLib.Models;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi.Services
 {
@@ -28,6 +29,7 @@ namespace CloudDragonApi.Services
             if (character == null)
                 return new NotFoundObjectResult(new { success = false, error = "Character not found." });
 
+            DebugLogger.Log($"Retrieving spell slots for character {character.Id}");
             return new OkObjectResult(new { success = true, spellSlots = character.SpellSlots });
         }
         [FunctionName("UseSpellSlot")]
@@ -57,6 +59,7 @@ namespace CloudDragonApi.Services
                 return new BadRequestObjectResult(new { success = false, error = "No available spell slots at that level." });
 
             character.SpellSlots[level]--;
+            DebugLogger.Log($"Character {character.Id} used a level {level} spell slot. Remaining: {character.SpellSlots[level]}");
 
             await characterOut.AddAsync(character);
             return new OkObjectResult(new { success = true, remaining = character.SpellSlots[level] });
@@ -86,6 +89,8 @@ namespace CloudDragonApi.Services
             {
                 character.SpellSlots[key] = GetMaxSpellSlots(character.Level, key);
             }
+
+            DebugLogger.Log($"Character {character.Id} completed long rest. Slots reset.");
 
             await characterOut.AddAsync(character);
             return new OkObjectResult(new { success = true, spellSlots = character.SpellSlots });

--- a/CloudDragon/CloudDragonApi/HttpTirgger.cs
+++ b/CloudDragon/CloudDragonApi/HttpTirgger.cs
@@ -3,6 +3,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi
 {
@@ -14,14 +15,16 @@ namespace CloudDragonApi
             ILogger log)
         {
             log.LogInformation("HealthCheck triggered.");
-
-            return new OkObjectResult(new
+            DebugLogger.Log("Health check endpoint hit");
+            var result = new
             {
                 success = true,
                 message = "CloudDragon API is up and running!",
                 version = "1.0.0", // You can increment this
                 timestamp = DateTime.UtcNow
-            });
+            };
+            DebugLogger.Log("Health check returning OK result");
+            return new OkObjectResult(result);
         }
     }
 }

--- a/CloudDragon/CloudDragonApi/ProcessJson.cs
+++ b/CloudDragon/CloudDragonApi/ProcessJson.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using CloudDragonLib;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi
 {
@@ -21,6 +22,7 @@ namespace CloudDragonApi
             ILogger log)
         {
             log.LogInformation("ProcessJson triggered");
+            DebugLogger.Log("ProcessJson received a request");
 
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
             if (string.IsNullOrWhiteSpace(requestBody))
@@ -33,6 +35,7 @@ namespace CloudDragonApi
             try
             {
                 payload = JsonConvert.DeserializeObject<JObject>(requestBody);
+                DebugLogger.Log("Payload parsed successfully");
             }
             catch (JsonException ex)
             {
@@ -44,6 +47,7 @@ namespace CloudDragonApi
             if (string.IsNullOrEmpty(type))
             {
                 log.LogWarning("Missing 'type' in JSON payload.");
+                DebugLogger.Log("Missing 'type' in request payload");
                 return new BadRequestObjectResult(new { success = false, error = "Missing 'type' in JSON payload." });
             }
 
@@ -57,11 +61,13 @@ namespace CloudDragonApi
 
                         var builder = new Character_Stats_Point_Buy();
                         var resultStats = builder.GenerateStats(stats);
+                        DebugLogger.Log("Point-buy stats generated");
                         return new OkObjectResult(new { success = true, data = resultStats });
 
                     case "roll-stats":
                         var roller = new Character_Stats_Dice();
                         var statBlock = roller.RollStats();
+                        DebugLogger.Log("Stats rolled successfully");
                         return new OkObjectResult(new { success = true, data = statBlock });
 
                     default:
@@ -75,6 +81,7 @@ namespace CloudDragonApi
             catch (Exception ex)
             {
                 log.LogError(ex, "Error during processing.");
+                DebugLogger.Log($"ProcessJson failed: {ex.Message}");
                 return new BadRequestObjectResult(new { success = false, error = ex.Message });
             }
         }

--- a/CloudDragon/CloudDragonApi/RollForSkillCheck.cs
+++ b/CloudDragon/CloudDragonApi/RollForSkillCheck.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi
 {
@@ -49,6 +50,8 @@ namespace CloudDragonApi
             int roll = rng.Next(1, 21); // d20
             int total = roll + input.Modifier;
             bool passed = total >= input.Dc;
+
+            DebugLogger.Log($"Skill check roll={roll}, modifier={input.Modifier}, dc={input.Dc}, total={total}, passed={passed}");
 
             log.LogInformation("Skill check: roll={Roll}, modifier={Modifier}, total={Total}, dc={Dc}, success={Success}",
                 roll, input.Modifier, total, input.Dc, passed);

--- a/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
+++ b/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using CloudDragonLib;
 using System;
 using System.Threading.Tasks;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi
 {
@@ -23,6 +24,8 @@ namespace CloudDragonApi
                 var roller = new Character_Stats_Dice();
                 var statBlock = roller.RollStats();
 
+                DebugLogger.Log($"Generated stat block: {string.Join(",", statBlock)}");
+
                 log.LogInformation("Stats rolled successfully.");
 
                 return new OkObjectResult(new
@@ -34,6 +37,7 @@ namespace CloudDragonApi
             catch (Exception ex)
             {
                 log.LogError(ex, "An error occurred while rolling stats.");
+                DebugLogger.Log($"Error rolling stats: {ex.Message}");
                 return new BadRequestObjectResult(new
                 {
                     success = false,

--- a/CloudDragon/CloudDragonApi/Utils/DebugLogger.cs
+++ b/CloudDragon/CloudDragonApi/Utils/DebugLogger.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace CloudDragonApi.Utils
+{
+    /// <summary>
+    /// Simple helper for writing debug information.
+    /// This can be toggled off by setting <see cref="IsDebugEnabled"/> to false.
+    /// </summary>
+    public static class DebugLogger
+    {
+        /// <summary>
+        /// Controls whether debug output is written to the console.
+        /// </summary>
+        public static bool IsDebugEnabled { get; set; } = true;
+
+        /// <summary>
+        /// Write a debug message to the console with timestamp.
+        /// </summary>
+        public static void Log(string message)
+        {
+            if (!IsDebugEnabled || string.IsNullOrEmpty(message))
+                return;
+
+            Console.WriteLine($"[DEBUG] {DateTime.UtcNow:O} - {message}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DebugLogger utility for standard debug output
- instrument CombatRollService, SpellSlotService, RollForStatsFunction, RollForSkillCheck, HttpTrigger and ProcessJson with debug logs

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414d60bef8832a99aad246a378c79d