### PR TITLE
Fix missing using directives

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellcastingService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellcastingService.cs
@@ -3,7 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using CloudDragonLib.Models;
 
 namespace CloudDragonApi.Services
 {


### PR DESCRIPTION
## Summary
- add missing `System.Linq` import to `LongRestFunction`
- add missing `System.Linq` import to `SpellSlotService`
- add required imports for `SpellcastingService`

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841588d9914832aa54a5610905fb0fe