### PR TITLE
Fix missing namespaces and usings

### DIFF
--- a/CloudDragon/Models/Combatant.cs
+++ b/CloudDragon/Models/Combatant.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace CloudDragonApi.Models
 {
     public class Combatant

--- a/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
+++ b/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
@@ -1,99 +1,101 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CloudDragonApi.Services;
 using CharacterModel = CloudDragonLib.Models.Character;
 
-public class CharacterContextEngine
+namespace CloudDragonApi.Services
 {
-    private readonly ILlmService _llmService;
-    private readonly ICharacterRepository _repository;
-    private readonly McpPromptBuilder _promptBuilder = new();
-
-    public CharacterContextEngine(ILlmService llmService, ICharacterRepository repository)
+    public class CharacterContextEngine
     {
-        _llmService = llmService;
-        _repository = repository;
-    }
+        private readonly ILlmService _llmService;
+        private readonly ICharacterRepository _repository;
+        private readonly McpPromptBuilder _promptBuilder = new();
 
-    public async Task<CharacterModel> BuildAndStoreCharacterAsync(CharacterModel character)
-    {
-        await GenerateMissingFieldsAsync(character);
-        await _repository.SaveAsync(character);
-        return character;
-    }
-
-    public async Task<CharacterModel> GenerateMissingFieldsAsync(CharacterModel character)
-    {
-        if (string.IsNullOrWhiteSpace(character.Appearance))
-            character.Appearance = await GenerateAppearanceAsync(character);
-
-        if (string.IsNullOrWhiteSpace(character.Personality))
-            character.Personality = await GeneratePersonalityAsync(character);
-
-        if (string.IsNullOrWhiteSpace(character.Backstory))
-            character.Backstory = await GenerateBackstoryAsync(character);
-
-        if (string.IsNullOrWhiteSpace(character.FlavorText))
-            character.FlavorText = await GenerateFlavorQuoteAsync(character);
-
-        return character;
-    }
-
-    public async Task<string> GenerateAppearanceAsync(CharacterModel character)
-    {
-        string prompt = _promptBuilder.BuildPrompt(character) +
-            "\nWrite a vivid physical description of this character. Focus on unique traits, attire, and demeanor.";
-
-        return await _llmService.GenerateAsync(prompt);
-    }
-
-    public async Task<string> GeneratePersonalityAsync(CharacterModel character)
-    {
-        string prompt = _promptBuilder.BuildPrompt(character) +
-            "\nDescribe this character's personality. Include quirks, virtues, flaws, and behavioral tendencies.";
-
-        return await _llmService.GenerateAsync(prompt);
-    }
-
-    public async Task<string> GenerateBackstoryAsync(CharacterModel character)
-    {
-        string prompt = BuildFlavorfulPrompt(character);
-        return await _llmService.GenerateAsync(prompt);
-    }
-
-    public async Task<string> GenerateFlavorQuoteAsync(CharacterModel character)
-    {
-        string prompt = _promptBuilder.BuildPrompt(character) +
-            "\nWrite a short, iconic quote that reflects this character's essence — something they might say in a dramatic moment.";
-
-        return await _llmService.GenerateAsync(prompt);
-    }
-
-    public async Task<Dictionary<string, int>> GenerateStatsAsync(CharacterModel character)
-    {
-        var stats = new Dictionary<string, int>
+        public CharacterContextEngine(ILlmService llmService, ICharacterRepository repository)
         {
-            ["STR"] = RollStat(),
-            ["DEX"] = RollStat(),
-            ["CON"] = RollStat(),
-            ["INT"] = RollStat(),
-            ["WIS"] = RollStat(),
-            ["CHA"] = RollStat()
-        };
+            _llmService = llmService;
+            _repository = repository;
+        }
 
-        return await Task.FromResult(stats); // keep async-compatible signature
+        public async Task<CharacterModel> BuildAndStoreCharacterAsync(CharacterModel character)
+        {
+            await GenerateMissingFieldsAsync(character);
+            await _repository.SaveAsync(character);
+            return character;
+        }
 
-        int RollStat() => Random.Shared.Next(8, 16); // adjust range as desired
-    }
+        public async Task<CharacterModel> GenerateMissingFieldsAsync(CharacterModel character)
+        {
+            if (string.IsNullOrWhiteSpace(character.Appearance))
+                character.Appearance = await GenerateAppearanceAsync(character);
 
-    private string BuildFlavorfulPrompt(CharacterModel character)
-    {
-        string context = _promptBuilder.BuildPrompt(character);
-        return
-            "You are a storyteller and world-builder for a Dungeons & Dragons campaign.\n" +
-            "Using the context below, write a compelling and flavorful backstory for the character.\n" +
-            "The story should highlight personality traits, moral values, and past events that shaped them.\n" +
-            "Use rich, engaging prose — the kind a DM could read aloud to set the scene.\n\n" +
-            context;
+            if (string.IsNullOrWhiteSpace(character.Personality))
+                character.Personality = await GeneratePersonalityAsync(character);
+
+            if (string.IsNullOrWhiteSpace(character.Backstory))
+                character.Backstory = await GenerateBackstoryAsync(character);
+
+            if (string.IsNullOrWhiteSpace(character.FlavorText))
+                character.FlavorText = await GenerateFlavorQuoteAsync(character);
+
+            return character;
+        }
+
+        public async Task<string> GenerateAppearanceAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nWrite a vivid physical description of this character. Focus on unique traits, attire, and demeanor.";
+
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GeneratePersonalityAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nDescribe this character's personality. Include quirks, virtues, flaws, and behavioral tendencies.";
+
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GenerateBackstoryAsync(CharacterModel character)
+        {
+            string prompt = BuildFlavorfulPrompt(character);
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GenerateFlavorQuoteAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nWrite a short, iconic quote that reflects this character's essence — something they might say in a dramatic moment.";
+
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<Dictionary<string, int>> GenerateStatsAsync(CharacterModel character)
+        {
+            var stats = new Dictionary<string, int>
+            {
+                ["STR"] = RollStat(),
+                ["DEX"] = RollStat(),
+                ["CON"] = RollStat(),
+                ["INT"] = RollStat(),
+                ["WIS"] = RollStat(),
+                ["CHA"] = RollStat()
+            };
+
+            return await Task.FromResult(stats); // keep async-compatible signature
+
+            int RollStat() => Random.Shared.Next(8, 16); // adjust range as desired
+        }
+
+        private string BuildFlavorfulPrompt(CharacterModel character)
+        {
+            string context = _promptBuilder.BuildPrompt(character);
+            return
+                "You are a storyteller and world-builder for a Dungeons & Dragons campaign.\n" +
+                "Using the context below, write a compelling and flavorful backstory for the character.\n" +
+                "The story should highlight personality traits, moral values, and past events that shaped them.\n" +
+                "Use rich, engaging prose — the kind a DM could read aloud to set the scene.\n\n" +
+                context;
+        }
     }
 }

--- a/CloudDragon/Models/ModelContext/ICharacterRepository.cs
+++ b/CloudDragon/Models/ModelContext/ICharacterRepository.cs
@@ -1,16 +1,13 @@
 using System.Threading.Tasks;
 using CharacterModel = CloudDragonLib.Models.Character;
-using System.Collections.Generic;
-using CloudDragonLib.Models;
+
 namespace CloudDragonApi.Services
 {
+    /// <summary>
+    /// Provides access to storing and retrieving <see cref="CharacterModel"/> data.
+    /// </summary>
     public interface ICharacterRepository
     {
-        /// <summary>
-        /// Retrieves a character by its ID.
-        // This interface defines the contract for a character repository, which is responsible for
-        // retrieving and saving character data. The `GetAsync` method retrieves a character by its ID,
-        
         Task SaveAsync(CharacterModel character);
         Task<CloudDragonLib.Models.Character> GetAsync(string id);
         // Task SaveAsync(CloudDragonLib.Models.Character character);

--- a/CloudDragon/Models/ModelContext/ILlmService.cs
+++ b/CloudDragon/Models/ModelContext/ILlmService.cs
@@ -1,4 +1,9 @@
-public interface ILlmService
+using System.Threading.Tasks;
+
+namespace CloudDragonApi.Services
 {
-    Task<string> GenerateAsync(string prompt);
+    public interface ILlmService
+    {
+        Task<string> GenerateAsync(string prompt);
+    }
 }

--- a/CloudDragon/Models/ModelContext/McpPromptBuilder.cs
+++ b/CloudDragon/Models/ModelContext/McpPromptBuilder.cs
@@ -2,44 +2,48 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using CloudDragonLib.Models;
 
-public class McpPromptBuilder
+namespace CloudDragonApi.Services
 {
-    public string BuildPrompt(object model)
+    public class McpPromptBuilder
     {
-        var type = model.GetType();
-
-        if (!Attribute.IsDefined(type, typeof(ModelContextAttribute)))
-            throw new InvalidOperationException($"Type {type.Name} is not marked with [ModelContext].");
-
-        var sb = new StringBuilder();
-        sb.AppendLine("Build a D&D character based on the following details:");
-
-        var props = type.GetProperties()
-            .Where(p => Attribute.IsDefined(p, typeof(ModelFieldAttribute)));
-
-        foreach (var prop in props)
+        public string BuildPrompt(object model)
         {
-            var attr = prop.GetCustomAttribute<ModelFieldAttribute>();
-            var value = prop.GetValue(model)?.ToString() ?? "(unspecified)";
-            sb.AppendLine($"{attr.Description}: {value}");
+            var type = model.GetType();
+
+            if (!Attribute.IsDefined(type, typeof(ModelContextAttribute)))
+                throw new InvalidOperationException($"Type {type.Name} is not marked with [ModelContext].");
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Build a D&D character based on the following details:");
+
+            var props = type.GetProperties()
+                .Where(p => Attribute.IsDefined(p, typeof(ModelFieldAttribute)));
+
+            foreach (var prop in props)
+            {
+                var attr = prop.GetCustomAttribute<ModelFieldAttribute>();
+                var value = prop.GetValue(model)?.ToString() ?? "(unspecified)";
+                sb.AppendLine($"{attr.Description}: {value}");
+            }
+
+            return sb.ToString();
         }
 
-        return sb.ToString();
+        public string BuildFlavorQuotePrompt(Character character)
+        {
+            return
+                $@"Write a short, poetic flavor quote for a Dungeons & Dragons character card.
+                The quote should reflect the character’s essence and fantasy theme.
+
+                Name: {character.Name}
+                Race: {character.Race}
+                Class: {character.Class}
+                Personality: {character.Personality}
+
+                Limit it to 30 words. Make it evocative and suitable for card-based storytelling games like Magic: The Gathering.";
+        }
+
     }
-
-    public string BuildFlavorQuotePrompt(Character character)
-    {
-        return
-            $@"Write a short, poetic flavor quote for a Dungeons & Dragons character card.
-            The quote should reflect the character’s essence and fantasy theme.
-
-            Name: {character.Name}
-            Race: {character.Race}
-            Class: {character.Class}
-            Personality: {character.Personality}
-
-            Limit it to 30 words. Make it evocative and suitable for card-based storytelling games like Magic: The Gathering.";
-    }
-
 }

--- a/CloudDragon/Models/ModelContext/MockLlmService.cs
+++ b/CloudDragon/Models/ModelContext/MockLlmService.cs
@@ -1,16 +1,19 @@
 using System.Threading.Tasks;
 
-public class MockLlmService : ILlmService
+namespace CloudDragonApi.Services
 {
-    public Task<string> GenerateAsync(string prompt)
+    public class MockLlmService : ILlmService
     {
-        // Simple mock: just echoes the prompt back with a pretend "backstory".
-        var response =
-            "[MOCK BACKSTORY GENERATED]\n" +
-            "This character has a mysterious past tied to ancient ruins and forgotten lore.\n" +
-            "Prompt used:\n" +
-            prompt;
+        public Task<string> GenerateAsync(string prompt)
+        {
+            // Simple mock: just echoes the prompt back with a pretend "backstory".
+            var response =
+                "[MOCK BACKSTORY GENERATED]\n" +
+                "This character has a mysterious past tied to ancient ruins and forgotten lore.\n" +
+                "Prompt used:\n" +
+                prompt;
 
-        return Task.FromResult(response);
+            return Task.FromResult(response);
+        }
     }
 }

--- a/CloudDragon/Models/ModelContext/ModelContextAttributes.cs
+++ b/CloudDragon/Models/ModelContext/ModelContextAttributes.cs
@@ -1,15 +1,18 @@
 using System;
 
-[AttributeUsage(AttributeTargets.Class)]
-public class ModelContextAttribute : Attribute { }
-
-[AttributeUsage(AttributeTargets.Property)]
-public class ModelFieldAttribute : Attribute
+namespace CloudDragonApi.Services
 {
-    public string Description { get; }
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ModelContextAttribute : Attribute { }
 
-    public ModelFieldAttribute(string description)
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ModelFieldAttribute : Attribute
     {
-        Description = description;
+        public string Description { get; }
+
+        public ModelFieldAttribute(string description)
+        {
+            Description = description;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add namespace and Task using to `ILlmService`
- place `MockLlmService` in `CloudDragonApi.Services` namespace
- add generic collection using in `Combatant`
- clean up indentation and spacing in model context services

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416aeb4824832ab361b70c996f512e