### PR TITLE
Add extended character generation and standard array

### DIFF
--- a/CloudDragon.Tests/CharacterContextEngineTests.cs
+++ b/CloudDragon.Tests/CharacterContextEngineTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Xunit;
+using CloudDragonApi.Services;
+using CloudDragonLib.Models;
+
+public class CharacterContextEngineTests
+{
+    [Fact]
+    public async Task GenerateMissingFields_populates_new_sections()
+    {
+        var llm = new MockLlmService();
+        var repo = new InMemoryCharacterRepository();
+        var engine = new CharacterContextEngine(llm, repo);
+        var character = new Character { Name = "Test", Race = "Elf", Class = "Ranger" };
+
+        await engine.GenerateMissingFieldsAsync(character);
+
+        Assert.False(string.IsNullOrWhiteSpace(character.Goals));
+        Assert.False(string.IsNullOrWhiteSpace(character.Allies));
+        Assert.False(string.IsNullOrWhiteSpace(character.Secrets));
+    }
+
+    private class InMemoryCharacterRepository : ICharacterRepository
+    {
+        public Task<Character> GetAsync(string id) => Task.FromResult<Character>(null);
+        public Task SaveAsync(Character c) => Task.CompletedTask;
+    }
+}

--- a/CloudDragon.Tests/FileCombatSessionRepositoryTests.cs
+++ b/CloudDragon.Tests/FileCombatSessionRepositoryTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+using CloudDragonApi.Models;
+
+public class FileCombatSessionRepositoryTests
+{
+    [Fact]
+    public async Task Save_and_get_round_trip()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "combat-tests");
+        var repo = new FileCombatSessionRepository(dir);
+        var session = new CombatSession { Name = "test-session" };
+
+        await repo.SaveAsync(session);
+        var loaded = await repo.GetAsync(session.Id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(session.Id, loaded.Id);
+        Directory.Delete(dir, true);
+    }
+}

--- a/CloudDragon.Tests/StandardArrayTests.cs
+++ b/CloudDragon.Tests/StandardArrayTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+public class StandardArrayTests
+{
+    [Fact]
+    public void Generate_returns_standard_array_values()
+    {
+        var stats = CharacterStatsStandardArray.Generate();
+        Assert.Equal(6, stats.Count);
+        Assert.Equal(15, stats["STR"]);
+        Assert.Equal(14, stats["DEX"]);
+        Assert.Equal(13, stats["CON"]);
+        Assert.Equal(12, stats["INT"]);
+        Assert.Equal(10, stats["WIS"]);
+        Assert.Equal(8, stats["CHA"]);
+    }
+}

--- a/CloudDragon/CloudDragonApi/Functions/Character/Character.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Character.cs
@@ -53,6 +53,15 @@ namespace CloudDragonLib.Models
         [ModelField("The backstory of the character.")]
         public string? Backstory { get; set; }
 
+        [ModelField("The character's personal goals or ambitions.")]
+        public string? Goals { get; set; }
+
+        [ModelField("Friends, allies or organizations the character is connected to.")]
+        public string? Allies { get; set; }
+
+        [ModelField("Secrets the character hides from others.")]
+        public string? Secrets { get; set; }
+
         [ModelField("A quote that reflects this character's essence.")]
         public string? FlavorText { get; set; }
 

--- a/CloudDragon/CloudDragonApi/Functions/Combat/FileCombatSessionRepository.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/FileCombatSessionRepository.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CloudDragonApi.Models
+{
+    /// <summary>
+    /// Simple file-based repository for storing combat sessions locally.
+    /// </summary>
+    public class FileCombatSessionRepository : ICombatSessionRepository
+    {
+        private readonly string _directory;
+
+        public FileCombatSessionRepository(string directory)
+        {
+            _directory = directory;
+            Directory.CreateDirectory(_directory);
+        }
+
+        public Task SaveAsync(CombatSession session)
+        {
+            string path = Path.Combine(_directory, $"{session.Id}.json");
+            string json = JsonConvert.SerializeObject(session, Formatting.Indented);
+            File.WriteAllText(path, json);
+            return Task.CompletedTask;
+        }
+
+        public Task<CombatSession?> GetAsync(string id)
+        {
+            string path = Path.Combine(_directory, $"{id}.json");
+            if (!File.Exists(path))
+                return Task.FromResult<CombatSession?>(null);
+            string json = File.ReadAllText(path);
+            var session = JsonConvert.DeserializeObject<CombatSession>(json);
+            return Task.FromResult(session);
+        }
+    }
+}

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ICombatSessionRepository.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ICombatSessionRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace CloudDragonApi.Models
+{
+    public interface ICombatSessionRepository
+    {
+        Task SaveAsync(CombatSession session);
+        Task<CombatSession?> GetAsync(string id);
+    }
+}

--- a/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
+++ b/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace CloudDragonApi
+{
+    public static class StandardArrayFunction
+    {
+        [FunctionName("StandardArray")]
+        public static async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "standard-array")] HttpRequest req,
+            ILogger log)
+        {
+            log.LogInformation("StandardArray endpoint triggered.");
+            var stats = CharacterStatsStandardArray.Generate();
+            return await Task.FromResult(new OkObjectResult(new { success = true, data = stats }));
+        }
+    }
+}

--- a/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
+++ b/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
@@ -31,8 +31,17 @@ namespace CloudDragonApi.Services
             if (string.IsNullOrWhiteSpace(character.Personality))
                 character.Personality = await GeneratePersonalityAsync(character);
 
-            if (string.IsNullOrWhiteSpace(character.Backstory))
-                character.Backstory = await GenerateBackstoryAsync(character);
+           if (string.IsNullOrWhiteSpace(character.Backstory))
+               character.Backstory = await GenerateBackstoryAsync(character);
+
+            if (string.IsNullOrWhiteSpace(character.Goals))
+                character.Goals = await GenerateGoalsAsync(character);
+
+            if (string.IsNullOrWhiteSpace(character.Allies))
+                character.Allies = await GenerateAlliesAsync(character);
+
+            if (string.IsNullOrWhiteSpace(character.Secrets))
+                character.Secrets = await GenerateSecretsAsync(character);
 
             if (string.IsNullOrWhiteSpace(character.FlavorText))
                 character.FlavorText = await GenerateFlavorQuoteAsync(character);
@@ -59,6 +68,27 @@ namespace CloudDragonApi.Services
         public async Task<string> GenerateBackstoryAsync(CharacterModel character)
         {
             string prompt = BuildFlavorfulPrompt(character);
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GenerateGoalsAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nList this character's primary goals or ambitions in a short paragraph.";
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GenerateAlliesAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nBriefly describe any notable allies or organizations connected to this character.";
+            return await _llmService.GenerateAsync(prompt);
+        }
+
+        public async Task<string> GenerateSecretsAsync(CharacterModel character)
+        {
+            string prompt = _promptBuilder.BuildPrompt(character) +
+                "\nReveal a secret this character keeps hidden from most people.";
             return await _llmService.GenerateAsync(prompt);
         }
 

--- a/CloudDragonLib/CharacterStatsStandardArray.cs
+++ b/CloudDragonLib/CharacterStatsStandardArray.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides the classic D&D standard array ability scores.
+/// </summary>
+public static class CharacterStatsStandardArray
+{
+    private static readonly int[] StandardArray = { 15, 14, 13, 12, 10, 8 };
+    private static readonly string[] AbilityNames = { "STR", "DEX", "CON", "INT", "WIS", "CHA" };
+
+    /// <summary>
+    /// Returns a dictionary of ability scores using the standard array in order.
+    /// </summary>
+    public static Dictionary<string, int> Generate()
+    {
+        var stats = new Dictionary<string, int>();
+        for (int i = 0; i < AbilityNames.Length; i++)
+            stats[AbilityNames[i]] = StandardArray[i];
+        return stats;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ A DND related project for Elastacloud + beyond.
 
 This is an open source project created to provide support with building for both DND and other ideas.
 Things it can be used for: 
- - Character creation 
- - Campaign Assistance
- - Document different ideas user's would have in mind
- - World building help
+- Character creation
+- Campaign Assistance
+- Document different ideas user's would have in mind
+- World building help
+- Standard array and point-buy ability score tools
+- File-based combat session persistence
 
- <h2 align="left">Getting Started </h2>
+<h2 align="left">Getting Started </h2>
 
- 
+Use the Azure Functions API to generate ability scores and manage combat.
+`/roll-stats` rolls 4d6 drop lowest, while `/standard-array` returns the standard array.
 
  <h2 align="left">Hopes for the project</h2>
 
@@ -41,4 +44,5 @@ dotnet test CloudDragonLib/CloudDragonLib.sln
 ```
 
 This command builds the solution and runs all unit tests including `CloudDragon.Tests`.
+Additional tests verify the new standard array method and character generation features.
 


### PR DESCRIPTION
## Summary
- add Goals, Allies and Secrets fields to character model
- extend CharacterContextEngine to generate new fields
- implement standard array ability score utility with Azure Function
- include file-based combat session repository
- document new features and add unit tests

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417bbb56b0832a988b4d82e2eba10e