### PR TITLE
Add tests, helper, GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,18 @@
+name: .NET Tests
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+    - name: Run tests
+      run: dotnet test CloudDragonLib/CloudDragonLib.sln --no-build --verbosity minimal

--- a/CloudDragon.Tests/CharacterStatsDiceTests.cs
+++ b/CloudDragon.Tests/CharacterStatsDiceTests.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+public class CharacterStatsDiceTests
+{
+    [Fact]
+    public void Generate_returns_scores_between_3_and_18()
+    {
+        var stats = CharacterStatsDice.Generate();
+        Assert.InRange(stats.Strength, 3, 18);
+        Assert.InRange(stats.Dexterity, 3, 18);
+        Assert.InRange(stats.Constitution, 3, 18);
+        Assert.InRange(stats.Intelligence, 3, 18);
+        Assert.InRange(stats.Wisdom, 3, 18);
+        Assert.InRange(stats.Charisma, 3, 18);
+    }
+}

--- a/CloudDragon.Tests/PointBuyBuilderTests.cs
+++ b/CloudDragon.Tests/PointBuyBuilderTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Xunit;
+
+public class PointBuyBuilderTests
+{
+    [Fact]
+    public void GenerateStats_returns_stats_for_valid_input()
+    {
+        var builder = new Character_Stats_Point_Buy();
+        var input = new Dictionary<string, int>
+        {
+            ["STR"] = 8,
+            ["DEX"] = 10,
+            ["CON"] = 12,
+            ["INT"] = 13,
+            ["WIS"] = 14,
+            ["CHA"] = 15
+        };
+        var result = builder.GenerateStats(input);
+        Assert.Equal(6, result.Count);
+        Assert.Equal(8, result["STR"]);
+        Assert.Equal(10, result["DEX"]);
+        Assert.Equal(12, result["CON"]);
+        Assert.Equal(13, result["INT"]);
+        Assert.Equal(14, result["WIS"]);
+        Assert.Equal(15, result["CHA"]);
+    }
+
+    [Fact]
+    public void GenerateStats_invalid_total_throws()
+    {
+        var builder = new Character_Stats_Point_Buy();
+        var input = new Dictionary<string, int>
+        {
+            ["STR"] = 15,
+            ["DEX"] = 15,
+            ["CON"] = 15,
+            ["INT"] = 15,
+            ["WIS"] = 15,
+            ["CHA"] = 15
+        };
+        Assert.Throws<ArgumentException>(() => builder.GenerateStats(input));
+    }
+}

--- a/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
+++ b/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
@@ -19,6 +19,11 @@ namespace CloudDragonApi
         {
             log.LogInformation("RollStats endpoint triggered.");
 
+            if (!ApiRequestHelper.IsAuthorized(req, log))
+            {
+                return new UnauthorizedResult();
+            }
+
             try
             {
                 var roller = new Character_Stats_Dice();

--- a/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
+++ b/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi
 {
@@ -15,6 +16,10 @@ namespace CloudDragonApi
             ILogger log)
         {
             log.LogInformation("StandardArray endpoint triggered.");
+            if (!ApiRequestHelper.IsAuthorized(req, log))
+            {
+                return new UnauthorizedResult();
+            }
             var stats = CharacterStatsStandardArray.Generate();
             return await Task.FromResult(new OkObjectResult(new { success = true, data = stats }));
         }

--- a/CloudDragon/CloudDragonApi/Utils/ApiRequestHelper.cs
+++ b/CloudDragon/CloudDragonApi/Utils/ApiRequestHelper.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace CloudDragonApi.Utils
+{
+    /// <summary>
+    /// Utility methods for working with HTTP requests.
+    /// </summary>
+    public static class ApiRequestHelper
+    {
+        /// <summary>
+        /// Reads and deserializes JSON from the request body.
+        /// </summary>
+        public static async Task<T?> ReadJsonAsync<T>(HttpRequest req, ILogger log)
+        {
+            var body = await new StreamReader(req.Body).ReadToEndAsync();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                log.LogWarning("Request body is empty");
+                return default;
+            }
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(body);
+            }
+            catch (JsonException ex)
+            {
+                log.LogError(ex, "Failed to deserialize request body to {Type}", typeof(T).Name);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Validates the API key provided via header 'x-api-key'.
+        /// </summary>
+        public static bool IsAuthorized(HttpRequest req, ILogger log)
+        {
+            var expected = System.Environment.GetEnvironmentVariable("API_KEY");
+            if (string.IsNullOrEmpty(expected))
+                return true; // no key required
+
+            if (!req.Headers.TryGetValue("x-api-key", out var provided) || provided != expected)
+            {
+                log.LogWarning("Unauthorized request missing or invalid API key");
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ dotnet test CloudDragonLib/CloudDragonLib.sln
 This command builds the solution and runs all unit tests including `CloudDragon.Tests`.
 Additional tests verify the new standard array method and character generation features.
 
+CI runs these tests automatically using GitHub Actions. See `.github/workflows/dotnet.yml` for details.
+


### PR DESCRIPTION
## Summary
- add API helper to centralize JSON parsing and API key validation
- add API key checks and use helper in multiple functions
- new unit tests for dice generation and point buy
- run tests in CI via GitHub Actions
- document automated tests in README

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln --no-build --verbosity minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68418455ae90832aacd3cbf22def85c6