### PR TITLE
Fix .NET version mismatch

### DIFF
--- a/CloudDragon.Tests/CloudDragon.Tests.csproj
+++ b/CloudDragon.Tests/CloudDragon.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/CloudDragon/CloudDragon.csproj
+++ b/CloudDragon/CloudDragon.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/CloudDragonLib/CloudDragonLib.csproj
+++ b/CloudDragonLib/CloudDragonLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -650,7 +650,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="bin\Debug\net6.0\" />
+    <Folder Include="bin\Debug\net8.0\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- align all projects and tests on .NET 8
- specify Azure Functions version for CloudDragon

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln --no-build --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684208d5fadc832aab5e0e56d49e3006