### PR TITLE
Fix unreachable code in GenerateStatsAsync method

### DIFF
--- a/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
+++ b/CloudDragon/Models/ModelContext/CharacterContextEngine.cs
@@ -102,6 +102,8 @@ namespace CloudDragonApi.Services
 
         public async Task<Dictionary<string, int>> GenerateStatsAsync(CharacterModel character)
         {
+            int RollStat() => Random.Shared.Next(8, 16); // adjust range as desired
+
             var stats = new Dictionary<string, int>
             {
                 ["STR"] = RollStat(),
@@ -113,8 +115,6 @@ namespace CloudDragonApi.Services
             };
 
             return await Task.FromResult(stats); // keep async-compatible signature
-
-            int RollStat() => Random.Shared.Next(8, 16); // adjust range as desired
         }
 
         private string BuildFlavorfulPrompt(CharacterModel character)


### PR DESCRIPTION
## Summary
- fix unreachable local function placement in `GenerateStatsAsync`

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842d71c68c0832ab3102b37ab4f3be3