### PR TITLE
Handle JSON deserialization errors when updating characters

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
@@ -56,9 +56,18 @@ namespace CloudDragonApi.Functions.Character
             return new NotFoundObjectResult(new { success = false, error = "Character not found." });
         }
 
-        string body = await new StreamReader(req.Body).ReadToEndAsync();
-        log.LogDebug("Update payload: {Body}", body);
-        var updates = JsonConvert.DeserializeObject<Character>(body);
+        Character updates;
+        try
+        {
+            string body = await new StreamReader(req.Body).ReadToEndAsync();
+            log.LogDebug("Update payload: {Body}", body);
+            updates = JsonConvert.DeserializeObject<Character>(body);
+        }
+        catch (JsonException ex)
+        {
+            log.LogError(ex, "UpdateCharacter failed to parse payload");
+            return new BadRequestObjectResult(new { success = false, error = "Invalid character update payload." });
+        }
         DebugLogger.Log("Parsed update payload");
 
         if (updates == null)


### PR DESCRIPTION
## Summary
- improve error handling in UpdateCharacter when reading update payloads

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469c4a42d8832aa8824ce89a9ae4b7