### PR TITLE
Support partial collection updates

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
@@ -78,7 +78,35 @@ namespace CloudDragonApi.Functions.Character
         existingChar.Class = updates.Class ?? existingChar.Class;
         existingChar.Race = updates.Race ?? existingChar.Race;
         existingChar.Level = updates.Level > 0 ? updates.Level : existingChar.Level;
-        existingChar.Stats = updates.Stats?.Count > 0 ? updates.Stats : existingChar.Stats;
+
+        if (updates.Stats != null)
+            foreach (var kvp in updates.Stats)
+                existingChar.Stats[kvp.Key] = kvp.Value;
+
+        if (updates.Classes != null)
+            foreach (var kvp in updates.Classes)
+                existingChar.Classes[kvp.Key] = kvp.Value;
+
+        if (updates.Subclasses != null)
+            foreach (var kvp in updates.Subclasses)
+                existingChar.Subclasses[kvp.Key] = kvp.Value;
+
+        if (updates.Equipped != null)
+            foreach (var kvp in updates.Equipped)
+                existingChar.Equipped[kvp.Key] = kvp.Value;
+
+        if (updates.SpellSlots != null)
+            foreach (var kvp in updates.SpellSlots)
+                existingChar.SpellSlots[kvp.Key] = kvp.Value;
+
+        if (updates.Inventory != null)
+            existingChar.Inventory = updates.Inventory;
+
+        if (updates.PreparedSpells != null)
+            existingChar.PreparedSpells = updates.PreparedSpells;
+
+        if (updates.CastedSpells != null)
+            existingChar.CastedSpells = updates.CastedSpells;
 
         await characterOut.AddAsync(existingChar);
         log.LogInformation("Character {Id} updated", existingChar.Id);


### PR DESCRIPTION
## Summary
- allow clearing of character lists by assigning empty collections
- iterate over dictionary fields to update individual keys

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469d0340f8832a8510b40c2378a9e5