### PR TITLE
Add XML docs and debug logs

### DIFF
--- a/CloudDragon/ArmorItemIdsConfig.cs
+++ b/CloudDragon/ArmorItemIdsConfig.cs
@@ -6,10 +6,16 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Identifier references for different armor categories stored in Cosmos DB.
+    /// </summary>
     public class ArmorItemIdsConfig
     {
+        /// <summary>Id used for heavy armor items.</summary>
         public string HeavyArmor { get; set; }
+        /// <summary>Id used for medium armor items.</summary>
         public string MediumArmor { get; set; }
+        /// <summary>Id used for light armor items.</summary>
         public string LightArmor { get; set; }
     }
 }

--- a/CloudDragon/CloudDragonApi/Functions/Combat/CombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/CombatSession.cs
@@ -13,19 +13,45 @@ using CloudDragonApi.Models;
 
 namespace CloudDragonApi.Models
 {
+    /// <summary>
+    /// Represents the state of an ongoing combat encounter.
+    /// </summary>
     public class CombatSession
     {
+        /// <summary>
+        /// Unique identifier for the session used as the Cosmos DB id/partition key.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; } = Guid.NewGuid().ToString();
 
+        /// <summary>
+        /// Friendly name for the encounter.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Ordered list of combatants participating in the encounter.
+        /// </summary>
         public List<Combatant> Combatants { get; set; } = new();
 
+        /// <summary>
+        /// Current round number of the encounter.
+        /// </summary>
         public int Round { get; set; } = 1;
+
+        /// <summary>
+        /// Index of the combatant whose turn is currently active.
+        /// </summary>
         public int TurnIndex { get; set; } = 0;
 
+        /// <summary>
+        /// Time the session was created in UTC.
+        /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+        /// <summary>
+        /// Arbitrary log messages for auditing the encounter.
+        /// </summary>
         public List<string> Log { get; set; } = new();
     }
 }

--- a/CloudDragon/CloudDragonApi/Functions/Combat/FileCombatSessionRepository.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/FileCombatSessionRepository.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using CloudDragonApi.Utils;
 
 namespace CloudDragonApi.Models
 {
@@ -11,27 +12,45 @@ namespace CloudDragonApi.Models
     {
         private readonly string _directory;
 
+        /// <summary>
+        /// Creates a new repository using the specified directory path.
+        /// </summary>
+        /// <param name="directory">Directory where session files are stored.</param>
         public FileCombatSessionRepository(string directory)
         {
             _directory = directory;
             Directory.CreateDirectory(_directory);
         }
 
+        /// <summary>
+        /// Saves the provided session to disk as JSON.
+        /// </summary>
+        /// <param name="session">Session to persist.</param>
         public Task SaveAsync(CombatSession session)
         {
             string path = Path.Combine(_directory, $"{session.Id}.json");
             string json = JsonConvert.SerializeObject(session, Formatting.Indented);
             File.WriteAllText(path, json);
+            DebugLogger.Log($"Saved combat session {session.Id} to {path}");
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Retrieves a session from disk by its identifier.
+        /// </summary>
+        /// <param name="id">Session id to load.</param>
+        /// <returns>The loaded session or <c>null</c> if not found.</returns>
         public Task<CombatSession?> GetAsync(string id)
         {
             string path = Path.Combine(_directory, $"{id}.json");
             if (!File.Exists(path))
+            {
+                DebugLogger.Log($"Session file not found: {path}");
                 return Task.FromResult<CombatSession?>(null);
+            }
             string json = File.ReadAllText(path);
             var session = JsonConvert.DeserializeObject<CombatSession>(json);
+            DebugLogger.Log($"Loaded combat session {id} from {path}");
             return Task.FromResult(session);
         }
     }

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ICombatSessionRepository.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ICombatSessionRepository.cs
@@ -2,9 +2,24 @@ using System.Threading.Tasks;
 
 namespace CloudDragonApi.Models
 {
+    /// <summary>
+    /// Abstraction for storing and retrieving combat sessions.
+    /// Implementations may persist sessions to any backing store such as
+    /// Cosmos DB or the file system.
+    /// </summary>
     public interface ICombatSessionRepository
     {
+        /// <summary>
+        /// Persists the given session to the underlying storage mechanism.
+        /// </summary>
+        /// <param name="session">Session to save.</param>
         Task SaveAsync(CombatSession session);
+
+        /// <summary>
+        /// Retrieves a previously saved session by its identifier.
+        /// </summary>
+        /// <param name="id">Unique session id.</param>
+        /// <returns>The session if found; otherwise <c>null</c>.</returns>
         Task<CombatSession?> GetAsync(string id);
     }
 }

--- a/CloudDragon/ItemsIdsConfig.cs
+++ b/CloudDragon/ItemsIdsConfig.cs
@@ -7,23 +7,44 @@ using CloudDragon.ItemIds;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Root configuration object containing item id lookups for many game areas.
+    /// Each property maps to a section in <c>appsettings.json</c> describing
+    /// identifiers for that category.
+    /// </summary>
     public class ItemIdsConfig
     {
+        /// <summary>Armor item identifiers.</summary>
         public ArmorItemIdsConfig Armor { get; set; }
+        /// <summary>Artificer class item identifiers.</summary>
         public ArtificerItemIdsConfig ArtificerClass { get; set; }
+        /// <summary>Background related item identifiers.</summary>
         public BackgroundsItemIdsConfig Backgrounds { get; set; }
+        /// <summary>Barbarian class item identifiers.</summary>
         public BarbarianItemIdsConfig BarbarianClass { get; set; }
+        /// <summary>Bard class item identifiers.</summary>
         public BardItemIdsConfig BardClass { get; set; }
+        /// <summary>Cleric class item identifiers.</summary>
         public ClericItemIdsConfig ClericClass { get; set; }
+        /// <summary>Druid class item identifiers.</summary>
         public DruidItemIdsConfig DruidClass { get; set; }
+        /// <summary>Fighter class item identifiers.</summary>
         public FighterItemIdsConfig FighterClass { get; set; }
+        /// <summary>Monk class item identifiers.</summary>
         public MonkItemIdsConfig MonkClass { get; set; }
+        /// <summary>Paladin class item identifiers.</summary>
         public PaladinItemIdsConfig PaladinClass { get; set; }
+        /// <summary>Ranger class item identifiers.</summary>
         public RangerItemIdsConfig RangerClass { get; set; }
+        /// <summary>Rogue class item identifiers.</summary>
         public RogueItemIdsConfig RogueClass { get; set; }
+        /// <summary>Sorcerer class item identifiers.</summary>
         public SorcererItemIdsConfig SorcererClass { get; set; }
+        /// <summary>Warlock class item identifiers.</summary>
         public WarlockItemIdsConfig WarlockClass { get; set; }
+        /// <summary>Weapon item identifiers.</summary>
         public WeaponsItemIdsConfig WeaponsClass { get; set; }
+        /// <summary>Wizard class item identifiers.</summary>
         public WizardItemIdsConfig WizardClass { get; set; }
 
     }

--- a/CloudDragon/PartitionKeysConfig.cs
+++ b/CloudDragon/PartitionKeysConfig.cs
@@ -7,20 +7,36 @@ using CloudDragon.PartitionKeys;
 
 namespace CloudDragon
 {
+    /// <summary>
+    /// Defines Cosmos DB partition keys for each character class and equipment category.
+    /// </summary>
     public class PartitionKeysConfig
     {
+        /// <summary>Partition keys for the Barbarian class.</summary>
         public BarbarianPartitionKeysConfig BarbarianClass { get; set; }
+        /// <summary>Partition keys for the Bard class.</summary>
         public BardPartitionKeysConfig BardClass { get; set; }
+        /// <summary>Partition keys for the Cleric class.</summary>
         public ClericPartitionKeysConfig ClericClass { get; set; }
+        /// <summary>Partition keys for the Druid class.</summary>
         public DruidPartitionKeysConfig DruidClass { get; set; }
+        /// <summary>Partition keys for the Fighter class.</summary>
         public FighterPartitionKeysConfig FighterClass { get; set; }
+        /// <summary>Partition keys for the Monk class.</summary>
         public MonkPartitionKeysConfig MonkClass { get; set; }
+        /// <summary>Partition keys for the Paladin class.</summary>
         public PaladinPartitionKeysConfig PaladinClass { get; set; }
+        /// <summary>Partition keys for the Ranger class.</summary>
         public RangerPartitionKeysConfig RangerClass { get; set; }
+        /// <summary>Partition keys for the Rogue class.</summary>
         public RoguePartitionKeysConfig RogueClass { get; set; }
+        /// <summary>Partition keys for the Sorcerer class.</summary>
         public SorcererPartitionKeysConfig SorcererClass { get; set; }
+        /// <summary>Partition keys for the Warlock class.</summary>
         public WarlockPartitionKeysConfig WarlockClass { get; set; }
+        /// <summary>Partition keys for the Wizard class.</summary>
         public WizardPartitionKeysConfig WizardClass { get; set; }
+        /// <summary>Partition keys for weapons data.</summary>
         public WeaponsPartitionKeysConfig Weapons { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- document CombatSession and repository interface
- document config classes for items and partition keys
- add debug logging to file-based combat session repository
- document AdvanceTurn function and log turn progression

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4fa99048832aa40b132f021d236a