### PR TITLE
Fix alias for Character in apply level up function

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/ApplyLevelUpFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/ApplyLevelUpFunction.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragonLib.Models;
+using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
@@ -23,11 +24,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
                 containerName: "Characters",
                 Connection = "CosmosDBConnection",
                 Id = "{id}",
-                PartitionKey = "{id}")] Character character,
+                PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
                 containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<Character> characterOut,
+                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             string id,
             ILogger log)
         {


### PR DESCRIPTION
## Summary
- alias `CharacterModel` in `ApplyLevelUpFunction`
- update Cosmos DB bindings to use the alias

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541f56423c832aac5a99cee0e6c3ed