### PR TITLE
Use alias for Races model in populator

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/RacesPopulator.cs
+++ b/CloudDragon/CloudDragonApi/Functions/RacesPopulator.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using CloudDragon.CloudDragonApi;
 using CloudDragonLib.Models;
+using RacesModel = CloudDragonLib.Models.Races;
 using CloudDragon.CloudDragonApi.Utils;
 
 
@@ -21,7 +22,7 @@ namespace CloudDragon.CloudDragonApi.Functions
         /// </summary>
         /// <param name="fileName">Optional source file name.</param>
         /// <returns>List of races.</returns>
-        Task<List<Races>> Populate(string fileName);
+        Task<List<RacesModel>> Populate(string fileName);
     }
 
     /// <summary>
@@ -29,13 +30,13 @@ namespace CloudDragon.CloudDragonApi.Functions
     /// </summary>
     public class RacesPopulator : IRacesPopulator
     {
-        public async Task<List<Races>> Populate(string fileName)
+        public async Task<List<RacesModel>> Populate(string fileName)
         {
             DebugLogger.Log($"Populating races from {fileName}");
-            var races = new List<Races>();
+            var races = new List<RacesModel>();
 
             // Human
-            Races humanRace = new Races("Human");
+            RacesModel humanRace = new RacesModel("Human");
             humanRace.AddAbilityBonus("STR", 1);
             humanRace.AddAbilityBonus("DEX", 1);
             humanRace.AddAbilityBonus("CON", 1);
@@ -45,54 +46,54 @@ namespace CloudDragon.CloudDragonApi.Functions
             races.Add(humanRace);
 
             // Dwarves
-            var dwarfHill = new Races("Dwarf (Hill)");
+            var dwarfHill = new RacesModel("Dwarf (Hill)");
             dwarfHill.AddAbilityBonus("CON", 2);
             races.Add(dwarfHill);
 
-            var dwarfMountain = new Races("Dwarf (Mountain)");
+            var dwarfMountain = new RacesModel("Dwarf (Mountain)");
             dwarfMountain.AddAbilityBonus("STR", 2);
             dwarfMountain.AddAbilityBonus("CON", 2); // Seems like a bug in original, added CON again here
             races.Add(dwarfMountain);
 
-            var dwarfGray = new Races("Dwarf (Gray/Duergar)");
+            var dwarfGray = new RacesModel("Dwarf (Gray/Duergar)");
             dwarfGray.AddAbilityBonus("STR", 1);
             dwarfGray.AddAbilityBonus("CON", 2);
             races.Add(dwarfGray);
 
-            var dwarfDuergar = new Races("Dwarf (Duergar)");
+            var dwarfDuergar = new RacesModel("Dwarf (Duergar)");
             dwarfDuergar.AddAbilityBonus("STR", 1);
             dwarfDuergar.AddAbilityBonus("CON", 2);
             races.Add(dwarfDuergar);
 
             // Elves (a few to demo)
-            var elfHigh = new Races("Elf (High)");
+            var elfHigh = new RacesModel("Elf (High)");
             elfHigh.AddAbilityBonus("DEX", 2);
             elfHigh.AddAbilityBonus("INT", 1);
             races.Add(elfHigh);
 
-            var elfWood = new Races("Elf (Wood)");
+            var elfWood = new RacesModel("Elf (Wood)");
             elfWood.AddAbilityBonus("DEX", 2);
             elfWood.AddAbilityBonus("WIS", 1);
             races.Add(elfWood);
 
-            var elfDrow = new Races("Elf (Drow)");
+            var elfDrow = new RacesModel("Elf (Drow)");
             elfDrow.AddAbilityBonus("DEX", 2);
             elfDrow.AddAbilityBonus("CHA", 1);
             races.Add(elfDrow);
 
             // Tiefling
-            var tiefling = new Races("Tiefling");
+            var tiefling = new RacesModel("Tiefling");
             tiefling.AddAbilityBonus("INT", 1);
             tiefling.AddAbilityBonus("CHA", 2);
             races.Add(tiefling);
 
-            var tieflingFeral = new Races("Tiefling (Feral)");
+            var tieflingFeral = new RacesModel("Tiefling (Feral)");
             tieflingFeral.AddAbilityBonus("DEX", 2);
             tieflingFeral.AddAbilityBonus("INT", 1);
             races.Add(tieflingFeral);
 
             // Satyr
-            var satyr = new Races("Satyr");
+            var satyr = new RacesModel("Satyr");
             satyr.AddAbilityBonus("DEX", 1);
             satyr.AddAbilityBonus("CHA", 2);
             races.Add(satyr);


### PR DESCRIPTION
## Summary
- add `RacesModel` alias for model type
- update interface and implementation to use the alias

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685420007790832a82d0d3ac74f0a41e