### PR TITLE
Fix CosmosDB attribute properties

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/ApplyRace.cs
+++ b/CloudDragon/CloudDragonApi/Functions/ApplyRace.cs
@@ -21,14 +21,14 @@ namespace CloudDragon.CloudDragonApi.Functions
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"ApplyRace triggered for {id}");

--- a/CloudDragon/CloudDragonApi/Functions/Character/AddItemToInventory.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/AddItemToInventory.cs
@@ -34,14 +34,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/ApplyLevelUpFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/ApplyLevelUpFunction.cs
@@ -34,14 +34,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/apply-levelup")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             string id,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/Character/CastCantripFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CastCantripFunction.cs
@@ -33,8 +33,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/cast-cantrip")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             string id,

--- a/CloudDragon/CloudDragonApi/Functions/Character/CharacterUtilities.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CharacterUtilities.cs
@@ -35,14 +35,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"ResetCharacterStats called for {id}");
@@ -72,14 +72,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"LevelUpCharacterSimple called for {id}");
@@ -108,8 +108,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             ILogger log)
@@ -148,18 +148,18 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Backgrounds",
-                Connection = "CosmosDBConnection")] IEnumerable<dynamic> backgrounds,
+                ContainerName: "Backgrounds",
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<dynamic> backgrounds,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"ApplyBackground called for {id}");
@@ -199,14 +199,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"AssignSpell called for {id}");
@@ -241,18 +241,18 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CloudDragonLib.Models.Character character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Feats",
-                Connection = "CosmosDBConnection")] IEnumerable<dynamic> feats,
+                ContainerName: "Feats",
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<dynamic> feats,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CloudDragonLib.Models.Character> characterOut,
             ILogger log)
         {
             DebugLogger.Log($"AddFeat called for {id}");

--- a/CloudDragon/CloudDragonApi/Functions/Character/CopyCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CopyCharacter.cs
@@ -27,14 +27,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/clone")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel sourceChar,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (sourceChar == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/CreateCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CreateCharacter.cs
@@ -32,8 +32,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             log.LogInformation("CreateCharacter endpoint hit");

--- a/CloudDragon/CloudDragonApi/Functions/Character/DeleteCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/DeleteCharacter.cs
@@ -31,14 +31,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "character/{id}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel characterToDelete,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             string id,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/Character/EquipItem.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/EquipItem.cs
@@ -22,14 +22,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/GetCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/GetCharacter.cs
@@ -28,8 +28,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "character/{id}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             string id,

--- a/CloudDragon/CloudDragonApi/Functions/Character/LevelUpOptionsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/LevelUpOptionsFunction.cs
@@ -22,8 +22,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/level-up-options")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             ILogger log)

--- a/CloudDragon/CloudDragonApi/Functions/Character/ListCharacters.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/ListCharacters.cs
@@ -28,9 +28,9 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "characters")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
+                ContainerName: "Characters",
                 SqlQuery = "SELECT * FROM c WHERE c.Level > 0",
-                Connection = "CosmosDBConnection")] IEnumerable<CharacterModel> characters,
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<CharacterModel> characters,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(ListCharacters));

--- a/CloudDragon/CloudDragonApi/Functions/Character/ListInventory.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/ListInventory.cs
@@ -28,8 +28,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             ILogger log)

--- a/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
@@ -18,14 +18,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/MockData.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/MockData.cs
@@ -16,8 +16,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "dev/mock-characters")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             var mockChars = new[]

--- a/CloudDragon/CloudDragonApi/Functions/Character/PrepareSpellsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/PrepareSpellsFunction.cs
@@ -20,14 +20,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/RemoveItemFromInventory.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/RemoveItemFromInventory.cs
@@ -21,14 +21,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/SaveCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/SaveCharacter.cs
@@ -20,8 +20,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character")] HttpRequest req,
         [CosmosDB(
             databaseName: "CloudDragonDB",
-            containerName: "Characters",
-            Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+            ContainerName: "Characters",
+            ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
         ILogger log)
     {
         log.LogInformation("SaveCharacter triggered");

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/LevelUpService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/LevelUpService.cs
@@ -42,14 +42,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/level-up")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             string id,
             ILogger log)
         {
@@ -81,14 +81,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/subclass")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             string id,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
@@ -22,8 +22,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "character/{id}/spell-slots")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             ILogger log)
@@ -40,14 +40,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)
@@ -73,14 +73,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SubclassService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SubclassService.cs
@@ -17,9 +17,9 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string className,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Classes",
+                ContainerName: "Classes",
                 SqlQuery = "SELECT * FROM c WHERE c.{partitionKey} = {className}",
-                Connection = "CosmosDBConnection")] IEnumerable<dynamic> allEntries,
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<dynamic> allEntries,
             ILogger log)
         {
             if (string.IsNullOrEmpty(className))

--- a/CloudDragon/CloudDragonApi/Functions/Character/UnequipItem.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/UnequipItem.cs
@@ -21,14 +21,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             string id,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection",
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CharacterModel character,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Characters",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+                ContainerName: "Characters",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
             ILogger log)
         {
             if (character == null)

--- a/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/UpdateCharacter.cs
@@ -33,14 +33,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
         [HttpTrigger(AuthorizationLevel.Function, "put", "patch", Route = "character/{id}")] HttpRequest req,
         [CosmosDB(
             databaseName: "CloudDragonDB",
-            containerName: "Characters",
-            Connection = "CosmosDBConnection",
+            ContainerName: "Characters",
+            ConnectionStringSetting = "CosmosDBConnection",
             Id = "{id}",
             PartitionKey = "{id}")] CharacterModel existingChar,
         [CosmosDB(
             databaseName: "CloudDragonDB",
-            containerName: "Characters",
-            Connection = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
+            ContainerName: "Characters",
+            ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CharacterModel> characterOut,
         string id,
         ILogger log)
     {

--- a/CloudDragon/CloudDragonApi/Functions/Combat/AdvanceTurn.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/AdvanceTurn.cs
@@ -35,14 +35,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{id}/advance")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
             Id = "{id}",
             PartitionKey = "{id}")] CombatSession session,
         [CosmosDB(
             databaseName: "CloudDragonDB",
-            containerName: "CombatSessions",
-            Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+            ContainerName: "CombatSessions",
+            ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             string id,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
@@ -23,14 +23,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string combatantId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(ApplyCondition));

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ClearConditionsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ClearConditionsFunction.cs
@@ -21,14 +21,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string combatantId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(ClearConditions));

--- a/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
@@ -22,8 +22,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(CreateCombatSession));

--- a/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
@@ -18,14 +18,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "combat/{id}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{id}",
                 PartitionKey = "{id}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             string id,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/Combat/GetCombatState.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/GetCombatState.cs
@@ -17,8 +17,8 @@ public static class GetCombatStateFunction
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = "combat/{id}")] HttpRequest req,
         [CosmosDB(
             databaseName: "CloudDragonDB",
-            containerName: "CombatSessions",
-            Connection = "CosmosDBConnection",
+            ContainerName: "CombatSessions",
+            ConnectionStringSetting = "CosmosDBConnection",
             Id = "{id}",
             PartitionKey = "{id}")] CombatSession session,
         string id,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/GetInitiativeOrder.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/GetInitiativeOrder.cs
@@ -18,8 +18,8 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string sessionId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             ILogger log)

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
@@ -23,14 +23,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string combatantId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(RemoveCondition));

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
@@ -22,14 +22,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string sessionId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(RollInitiative));

--- a/CloudDragon/CloudDragonApi/Functions/Combat/UpdateCombatant.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/UpdateCombatant.cs
@@ -21,14 +21,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             [HttpTrigger(AuthorizationLevel.Function, "patch", Route = "combat/{sessionId}/combatant/{name}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             string sessionId,
             string name,
             ILogger log)

--- a/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
@@ -26,14 +26,14 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
             string combatantId,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection",
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection",
                 Id = "{sessionId}",
                 PartitionKey = "{sessionId}")] CombatSession session,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "CombatSessions",
-                Connection = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
+                ContainerName: "CombatSessions",
+                ConnectionStringSetting = "CosmosDBConnection")] IAsyncCollector<CombatSession> sessionOut,
             ILogger log)
         {
             log.LogRequestDetails(req, nameof(UseCombatAction));

--- a/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableCantrips.cs
+++ b/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableCantrips.cs
@@ -19,9 +19,9 @@ namespace CloudDragon.CloudDragonApi.Functions.SpellCasting
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "cantrips/{className}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Spells",
+                ContainerName: "Spells",
                 SqlQuery = "SELECT * FROM c WHERE c.ClassName = {className} AND c.Type = 'Cantrip'",
-                Connection = "CosmosDBConnection")] IEnumerable<dynamic> cantrips,
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<dynamic> cantrips,
             string className,
             ILogger log)
         {

--- a/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableSpells.cs
+++ b/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableSpells.cs
@@ -19,9 +19,9 @@ namespace CloudDragon.CloudDragonApi.Functions.SpellCasting
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "spells/{className}/{level}")] HttpRequest req,
             [CosmosDB(
                 databaseName: "CloudDragonDB",
-                containerName: "Spells",
+                ContainerName: "Spells",
                 SqlQuery = "SELECT * FROM c WHERE c.ClassName = {className} AND c.Level = {level}",
-                Connection = "CosmosDBConnection")] IEnumerable<dynamic> spells,
+                ConnectionStringSetting = "CosmosDBConnection")] IEnumerable<dynamic> spells,
             string className,
             int level,
             ILogger log)


### PR DESCRIPTION
## Summary
- correct property casing in Cosmos DB attributes
- use `ConnectionStringSetting` instead of `Connection` for Cosmos DB bindings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554cb23230832aa7131018853d1c03