### PR TITLE
Add docs for item ID and partition configs

### DIFF
--- a/CloudDragon/Ability_Score_Class.cs
+++ b/CloudDragon/Ability_Score_Class.cs
@@ -6,10 +6,19 @@ using System.Threading.Tasks;
 
 namespace CloudDragon
 {
+    /// <summary>
+    /// Simple container for storing and modifying ability scores.
+    /// </summary>
     internal class Ability_Score_Class
     {
+        /// <summary>
+        /// Current ability scores keyed by ability name.
+        /// </summary>
         public Dictionary<string, int> AbilityScores { get; private set; }
 
+        /// <summary>
+        /// Initializes all ability scores to zero.
+        /// </summary>
         public Ability_Score_Class()
         {
             AbilityScores = new Dictionary<string, int>
@@ -22,6 +31,11 @@ namespace CloudDragon
                 { "Charisma", 0 }
             };
         }
+        /// <summary>
+        /// Sets a specific ability score.
+        /// </summary>
+        /// <param name="abilityName">Ability name.</param>
+        /// <param name="score">Score value.</param>
         public void SetAbilityScore(string abilityName, int score)
         {
             if (AbilityScores.ContainsKey(abilityName))
@@ -34,6 +48,11 @@ namespace CloudDragon
             }
         }
 
+        /// <summary>
+        /// Retrieves the value for the specified ability.
+        /// </summary>
+        /// <param name="abilityName">Ability name.</param>
+        /// <returns>The current score.</returns>
         public int GetAbilityScore(string abilityName)
         {
             if (AbilityScores.ContainsKey(abilityName))
@@ -45,6 +64,10 @@ namespace CloudDragon
                 throw new ArgumentException("Invalid ability name.");
             }
         }
+        /// <summary>
+        /// Applies a set of racial bonuses to this stat block.
+        /// </summary>
+        /// <param name="racialBonuses">Bonus values keyed by ability.</param>
         public void ApplyRacialBonus(Dictionary<string, int> racialBonuses)
         {
             foreach (var bonus in racialBonuses)
@@ -60,6 +83,9 @@ namespace CloudDragon
             }
         }
 
+        /// <summary>
+        /// Returns a formatted string of ability names and values.
+        /// </summary>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/CloudDragon/ArtificerItemIdsConfig.cs
+++ b/CloudDragon/ArtificerItemIdsConfig.cs
@@ -6,12 +6,20 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Item identifiers for various Artificer subclasses stored in Cosmos DB.
+    /// </summary>
     public class ArtificerItemIdsConfig
     {
+        /// <summary>Base Artificer class items.</summary>
         public string Base { get; set; }
+        /// <summary>Alchemist specialization items.</summary>
         public string Alchemist { get; set; }
+        /// <summary>Armorer specialization items.</summary>
         public string Armorer { get; set; }
+        /// <summary>Artillerist specialization items.</summary>
         public string Artillerist { get; set; }
+        /// <summary>Battle Smith specialization items.</summary>
         public string BattleSmith { get; set; }
     }
 }

--- a/CloudDragon/ArtificerPartitionKeysConfig.cs
+++ b/CloudDragon/ArtificerPartitionKeysConfig.cs
@@ -6,12 +6,20 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.PartitionKeys
 {
+    /// <summary>
+    /// Partition key names for Artificer data in Cosmos DB.
+    /// </summary>
     public class ArtificerPartitionKeysConfig
     {
+        /// <summary>Base Artificer partition.</summary>
         public string Base { get; set; }
+        /// <summary>Alchemist subclass partition.</summary>
         public string Alchemist { get; set; }
+        /// <summary>Armorer subclass partition.</summary>
         public string Armorer { get; set; }
+        /// <summary>Artillerist subclass partition.</summary>
         public string Artillerist { get; set; }
+        /// <summary>Battle Smith subclass partition.</summary>
         public string BattleSmith { get; set; }
     }
 }

--- a/CloudDragon/BarbarianItemIdsConfig.cs
+++ b/CloudDragon/BarbarianItemIdsConfig.cs
@@ -6,16 +6,28 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Cosmos DB identifiers for Barbarian class options.
+    /// </summary>
     public class BarbarianItemIdsConfig
     {
+        /// <summary>Base Barbarian items.</summary>
         public string Base { get; set; }
+        /// <summary>Berserker subclass items.</summary>
         public string Berserker { get; set; }
+        /// <summary>Totem Warrior subclass items.</summary>
         public string TotemWarrior { get; set; }
+        /// <summary>Ancestral Guardian subclass items.</summary>
         public string AncestralGuardian { get; set; }
+        /// <summary>Battlerager subclass items.</summary>
         public string Battlerager { get; set; }
+        /// <summary>Beast subclass items.</summary>
         public string Beast { get; set; }
+        /// <summary>Storm Herald subclass items.</summary>
         public string StormHerald { get; set; }
+        /// <summary>Wild Magic subclass items.</summary>
         public string WildMagic { get; set; }
+        /// <summary>Zealot subclass items.</summary>
         public string Zealot { get; set; }
     }
 }

--- a/CloudDragon/BardItemIdsConfig.cs
+++ b/CloudDragon/BardItemIdsConfig.cs
@@ -6,26 +6,48 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Maps Bard subclass names to item identifiers in Cosmos DB.
+    /// </summary>
     public class BardItemIdsConfig
     {
+        /// <summary>Base Bard class items.</summary>
         public string Base { get; set; }
+        /// <summary>College of Lore items.</summary>
         public string CollegeOfLore { get; set; }
+        /// <summary>College of Creation items.</summary>
         public string CollegeOfCreation { get; set; }
+        /// <summary>College of Eloquence items.</summary>
         public string CollegeOfEloquence { get; set; }
+        /// <summary>College of Glamour items.</summary>
         public string CollegeOfGlamour { get; set; }
+        /// <summary>College of Spirits items.</summary>
         public string CollegeOfSpirits { get; set; }
+        /// <summary>College of Swords items.</summary>
         public string CollegeOfSwords { get; set; }
+        /// <summary>College of Valor items.</summary>
         public string CollegeOfValor { get; set; }
+        /// <summary>College of Whispers items.</summary>
         public string CollegeOfWhispers { get; set; }
+        /// <summary>Cantrip item identifiers.</summary>
         public string Cantrips { get; set; }
+        /// <summary>1st-level spell item identifiers.</summary>
         public string Level1Spells { get; set; }
+        /// <summary>2nd-level spell item identifiers.</summary>
         public string Level2Spells { get; set; }
+        /// <summary>3rd-level spell item identifiers.</summary>
         public string Level3Spells { get; set; }
+        /// <summary>4th-level spell item identifiers.</summary>
         public string Level4Spells { get; set; }
+        /// <summary>5th-level spell item identifiers.</summary>
         public string Level5Spells { get; set; }
+        /// <summary>6th-level spell item identifiers.</summary>
         public string Level6Spells { get; set; }
+        /// <summary>7th-level spell item identifiers.</summary>
         public string Level7Spells { get; set; }
+        /// <summary>8th-level spell item identifiers.</summary>
         public string Level8Spells { get; set; }
+        /// <summary>9th-level spell item identifiers.</summary>
         public string Level9Spells { get; set; }
     }
 

--- a/CloudDragon/ClericItemIdsConfig.cs
+++ b/CloudDragon/ClericItemIdsConfig.cs
@@ -6,8 +6,12 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Item identifiers for Cleric domains and spell levels.
+    /// </summary>
     public class ClericItemIdsConfig
     {
+        /// <summary>Base Cleric class items.</summary>
         public string Base { get; set; }
         public string Life { get; set; }
         public string Light { get; set; }
@@ -23,15 +27,25 @@ namespace CloudDragon.ItemIds
         public string Trickery { get; set; }
         public string Twilight { get; set; }
         public string War { get; set; }
+        /// <summary>Cantrip item identifiers.</summary>
         public string Cantrips { get; set; }
+        /// <summary>1st-level spell item identifiers.</summary>
         public string Level1Spells { get; set; }
+        /// <summary>2nd-level spell item identifiers.</summary>
         public string Level2Spells { get; set; }
+        /// <summary>3rd-level spell item identifiers.</summary>
         public string Level3Spells { get; set; }
+        /// <summary>4th-level spell item identifiers.</summary>
         public string Level4Spells { get; set; }
+        /// <summary>5th-level spell item identifiers.</summary>
         public string Level5Spells { get; set; }
+        /// <summary>6th-level spell item identifiers.</summary>
         public string Level6Spells { get; set; }
+        /// <summary>7th-level spell item identifiers.</summary>
         public string Level7Spells { get; set; }
+        /// <summary>8th-level spell item identifiers.</summary>
         public string Level8Spells { get; set; }
+        /// <summary>9th-level spell item identifiers.</summary>
         public string Level9Spells { get; set; }
     }
 }

--- a/CloudDragon/CloudDragonApi/DescribeAPI.cs
+++ b/CloudDragon/CloudDragonApi/DescribeAPI.cs
@@ -9,15 +9,18 @@ using Microsoft.Extensions.Logging;
 
 namespace CloudDragon.CloudDragonApi.Functions
 {
+    /// <summary>
+    /// Provides a simple listing of available API endpoints.
+    /// </summary>
     public static class DescribeApiFunction
     {
-        [FunctionName("DescribeApi")]
         /// <summary>
         /// Returns a JSON object describing the available CloudDragon API endpoints.
         /// </summary>
         /// <param name="req">The incoming HTTP request.</param>
-        /// <param name="context">The current function execution context.</param>
+        /// <param name="logger">Function logger.</param>
         /// <returns>The HTTP response containing the list of endpoints.</returns>
+        [FunctionName("DescribeApi")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "describe")] HttpRequest req,
             ILogger logger)

--- a/CloudDragon/CloudDragonApi/Functions/ApplyRace.cs
+++ b/CloudDragon/CloudDragonApi/Functions/ApplyRace.cs
@@ -13,8 +13,20 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions
 {
+    /// <summary>
+    /// Azure Function that applies a racial bonus set to a character.
+    /// </summary>
     public static class ApplyRaceFunction
     {
+        /// <summary>
+        /// Applies the chosen race to the provided character document.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request containing the race name.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character record from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding for persisting changes.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Details about the applied race.</returns>
         [FunctionName("ApplyRace")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/apply-race")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SpellSlotService.cs
@@ -15,8 +15,14 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Helper functions for retrieving and modifying a character's spell slots.
+    /// </summary>
     public static class SpellSlotService 
     {
+        /// <summary>
+        /// Returns the current spell slot counts for the specified character.
+        /// </summary>
         [FunctionName("GetSpellSlots")]
         public static IActionResult GetSpellSlots(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "character/{id}/spell-slots")] HttpRequest req,
@@ -34,6 +40,9 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             DebugLogger.Log($"Retrieving spell slots for character {character.Id}");
             return new OkObjectResult(new { success = true, spellSlots = character.SpellSlots });
         }
+        /// <summary>
+        /// Consumes a spell slot of the specified level if available.
+        /// </summary>
         [FunctionName("UseSpellSlot")]
         public static async Task<IActionResult> UseSpellSlot(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/spell-slots/use")] HttpRequest req,
@@ -67,6 +76,9 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return new OkObjectResult(new { success = true, remaining = character.SpellSlots[level] });
         }
 
+        /// <summary>
+        /// Resets all spell slots to their maximum values after a long rest.
+        /// </summary>
         [FunctionName("LongRestRecoverSlots")]
         public static async Task<IActionResult> LongRestRecoverSlots(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/long-rest")] HttpRequest req,
@@ -86,7 +98,7 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             if (character == null)
                 return new NotFoundObjectResult(new { success = false, error = "Character not found." });
 
-            // TODO: Replace this with proper per-class slot recovery later if needed.
+            // Currently assumes full caster progression for all classes.
             foreach (var key in character.SpellSlots.Keys.ToList())
             {
                 character.SpellSlots[key] = GetMaxSpellSlots(character.Level, key);

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
@@ -14,8 +14,14 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Applies a combat condition to a specific combatant.
+    /// </summary>
     public static class ApplyConditionFunction
     {
+        /// <summary>
+        /// Adds the given condition to the combatant if present.
+        /// </summary>
         [FunctionName("ApplyCondition")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{sessionId}/combatant/{combatantId}/apply-condition")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
@@ -15,8 +15,14 @@ using CloudDragon.CloudDragonApi.Functions.Combat;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Azure Function endpoints for creating a new combat session.
+    /// </summary>
     public static class CreateCombatSessionFunction
     {
+        /// <summary>
+        /// Creates a new combat session from the provided combatants.
+        /// </summary>
         [FunctionName("CreateCombatSession")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
@@ -10,9 +10,15 @@ using System.Linq;
 using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
+    /// <summary>
+    /// Marks an existing combat session as ended and archives combatants.
+    /// </summary>
 {
     public static class EndCombatSessionFunction
     {
+        /// <summary>
+        /// Flags the specified combat session as ended.
+        /// </summary>
         [FunctionName("EndCombatSession")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "combat/{id}")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
@@ -14,8 +14,14 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Removes a specified condition from a combatant.
+    /// </summary>
     public static class RemoveConditionFunction
     {
+        /// <summary>
+        /// Removes the condition if it exists on the specified combatant.
+        /// </summary>
         [FunctionName("RemoveCondition")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{sessionId}/combatant/{combatantId}/remove-condition")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
@@ -14,8 +14,14 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Functions for determining combat initiative order.
+    /// </summary>
     public static class RollInitiative
     {
+        /// <summary>
+        /// Rolls initiative for every combatant in the session.
+        /// </summary>
         [FunctionName("RollInitiative")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{sessionId}/roll-initiative")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
@@ -17,8 +17,14 @@ using CharacterModel = CloudDragon.Models.Combatant;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Handles combat actions like attacking, dodging, and taking cover.
+    /// </summary>
     public static class UseCombatAction
     {
+        /// <summary>
+        /// Executes a combatant action within an existing combat session.
+        /// </summary>
         [FunctionName("UseCombatAction")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{sessionId}/combatant/{combatantId}/action")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableCantrips.cs
+++ b/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableCantrips.cs
@@ -12,8 +12,18 @@ using CloudDragonLib.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.SpellCasting
 {
+    /// <summary>
+    /// Retrieves cantrip spells for the specified class.
+    /// </summary>
     public static class GetAvailableCantrips
     {
+        /// <summary>
+        /// Returns all matching cantrips from the Cosmos DB container.
+        /// </summary>
+        /// <param name="req">HTTP request.</param>
+        /// <param name="cantrips">Query results from Cosmos DB.</param>
+        /// <param name="className">Player class name.</param>
+        /// <param name="log">Function logger.</param>
         [FunctionName("GetAvailableCantrips")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "cantrips/{className}")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableSpells.cs
+++ b/CloudDragon/CloudDragonApi/Functions/SpellCasting/GetAvailableSpells.cs
@@ -12,8 +12,19 @@ using CloudDragonLib.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.SpellCasting
 {
+    /// <summary>
+    /// Retrieves leveled spells for the specified class and level.
+    /// </summary>
     public static class GetAvailableSpells
     {
+        /// <summary>
+        /// Queries the Cosmos DB container for matching spells.
+        /// </summary>
+        /// <param name="req">HTTP request.</param>
+        /// <param name="spells">Query result set.</param>
+        /// <param name="className">Name of the caster class.</param>
+        /// <param name="level">Spell level requested.</param>
+        /// <param name="log">Function logger.</param>
         [FunctionName("GetAvailableSpells")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "spells/{className}/{level}")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/HealthCheckFunction.cs
+++ b/CloudDragon/CloudDragonApi/HealthCheckFunction.cs
@@ -7,8 +7,16 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi
 {
+    /// <summary>
+    /// Simple health check endpoint to verify the API is running.
+    /// </summary>
     public static class HealthCheckFunction
     {
+        /// <summary>
+        /// Responds with a timestamp and version string.
+        /// </summary>
+        /// <param name="req">Incoming request.</param>
+        /// <param name="log">Function logger.</param>
         [FunctionName("HealthCheck")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "health")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/RollForSkillCheck.cs
+++ b/CloudDragon/CloudDragonApi/RollForSkillCheck.cs
@@ -9,14 +9,29 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi
 {
+    /// <summary>
+    /// Input payload for performing a skill check.
+    /// </summary>
     public class SkillCheckInput
     {
+        /// <summary>Bonus modifier applied to the d20 roll.</summary>
         public int Modifier { get; set; } = 0;
+
+        /// <summary>Difficulty class that must be met or exceeded.</summary>
         public int Dc { get; set; } = 10;
     }
 
+    /// <summary>
+    /// Azure Function that simulates a single skill check roll.
+    /// </summary>
     public static class RollForSkillCheck
     {
+        /// <summary>
+        /// Performs the skill check using the provided modifiers.
+        /// </summary>
+        /// <param name="req">HTTP request containing <see cref="SkillCheckInput"/>.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Roll result data.</returns>
         [FunctionName("RollForSkillCheck")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "skill-check")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
+++ b/CloudDragon/CloudDragonApi/RollForStatsFunction.cs
@@ -10,8 +10,17 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi
 {
+    /// <summary>
+    /// Azure Function that rolls six ability scores using 4d6 drop-low.
+    /// </summary>
     public static class RollForStatsFunction
     {
+        /// <summary>
+        /// Generates a new stat block and returns it to the caller.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>List of six ability scores.</returns>
         [FunctionName("RollStats")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "roll-stats")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
+++ b/CloudDragon/CloudDragonApi/StandardArrayFunction.cs
@@ -8,8 +8,17 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi
 {
+    /// <summary>
+    /// Azure Function that returns the 5e standard array of ability scores.
+    /// </summary>
     public static class StandardArrayFunction
     {
+        /// <summary>
+        /// HTTP entry point for retrieving the standard array.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>The standard array wrapped in an <see cref="IActionResult"/>.</returns>
         [FunctionName("StandardArray")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "standard-array")] HttpRequest req,

--- a/CloudDragon/Cosmos_Loader.cs
+++ b/CloudDragon/Cosmos_Loader.cs
@@ -6,12 +6,19 @@ using System.Threading.Tasks;
 
 namespace CloudDragon
 {
+    /// <summary>
+    /// Utility wrapper for interacting with Cosmos DB containers.
+    /// </summary>
     public class Cosmos_Loader
     {
         private CosmosClient _client;
         private Database _database;
         private Dictionary<string, Container> _containers; // To hold multiple containers
 
+        /// <summary>
+        /// Initializes the loader and reads configuration for Cosmos DB.
+        /// </summary>
+        /// <param name="configuration">Application configuration.</param>
         public Cosmos_Loader(IConfiguration configuration)
         {
             var cosmosSettings = configuration.GetSection("CosmosDb");
@@ -44,6 +51,12 @@ namespace CloudDragon
             }
         }
 
+        /// <summary>
+        /// Creates or updates an item in the given container.
+        /// </summary>
+        /// <param name="containerName">Target container name.</param>
+        /// <param name="item">The item to save.</param>
+        /// <param name="partitionKey">Partition key for the item.</param>
         public async Task UpsertItemAsync(string containerName, object item, string partitionKey)
         {
             if (_containers.ContainsKey(containerName))
@@ -57,6 +70,13 @@ namespace CloudDragon
             }
         }
 
+        /// <summary>
+        /// Retrieves an item by id from the specified container.
+        /// </summary>
+        /// <param name="containerName">Container name.</param>
+        /// <param name="itemId">Item identifier.</param>
+        /// <param name="partitionKeyValue">Partition key value.</param>
+        /// <returns>The item if found; otherwise <c>null</c>.</returns>
         public async Task<dynamic> GetItemByIdAsync(string containerName, string itemId, string partitionKeyValue)
         {
             if (_containers.ContainsKey(containerName))
@@ -87,6 +107,9 @@ namespace CloudDragon
             }
         }
 
+        /// <summary>
+        /// Writes all items from every registered container to the console.
+        /// </summary>
         public async Task QueryAllItemsFromAllContainersAsync()
         {
             foreach (var containerEntry in _containers)

--- a/CloudDragon/DruidItemIdsConfig.cs
+++ b/CloudDragon/DruidItemIdsConfig.cs
@@ -6,8 +6,12 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Item identifiers for Druid circles and spell lists.
+    /// </summary>
     public class DruidItemIdsConfig
     {
+        /// <summary>Base Druid class items.</summary>
         public string Base { get; set; }
         public string CircleOfTheLand { get; set; }
         public string CircleOfTheMoon { get; set; }
@@ -16,15 +20,25 @@ namespace CloudDragon.ItemIds
         public string CircleOfSpores { get; set; }
         public string CircleOfStars { get; set; }
         public string CircleOfWildfire { get; set; }
+        /// <summary>Cantrip item identifiers.</summary>
         public string Cantrips { get; set; }
+        /// <summary>1st-level spell item identifiers.</summary>
         public string Level1Spells { get; set; }
+        /// <summary>2nd-level spell item identifiers.</summary>
         public string Level2Spells { get; set; }
+        /// <summary>3rd-level spell item identifiers.</summary>
         public string Level3Spells { get; set; }
+        /// <summary>4th-level spell item identifiers.</summary>
         public string Level4Spells { get; set; }
+        /// <summary>5th-level spell item identifiers.</summary>
         public string Level5Spells { get; set; }
+        /// <summary>6th-level spell item identifiers.</summary>
         public string Level6Spells { get; set; }
+        /// <summary>7th-level spell item identifiers.</summary>
         public string Level7Spells { get; set; }
+        /// <summary>8th-level spell item identifiers.</summary>
         public string Level8Spells { get; set; }
+        /// <summary>9th-level spell item identifiers.</summary>
         public string Level9Spells { get; set; }
     }
 }

--- a/CloudDragon/FighterItemIdsConfig.cs
+++ b/CloudDragon/FighterItemIdsConfig.cs
@@ -6,10 +6,16 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Item identifiers for Fighter archetypes.
+    /// </summary>
     public class FighterItemIdsConfig
     {
+        /// <summary>Base Fighter class items.</summary>
         public string Base { get; set; }
+        /// <summary>Champion archetype items.</summary>
         public string Champion { get; set; }
+        /// <summary>Battle Master archetype items.</summary>
         public string BattleMaster { get; set; }
         public string ArcaneArcher { get; set; }
         public string Banneret { get; set; }

--- a/CloudDragon/FighterPartitionKeysConfig.cs
+++ b/CloudDragon/FighterPartitionKeysConfig.cs
@@ -6,10 +6,16 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.PartitionKeys
 {
+    /// <summary>
+    /// Partition keys used for Fighter archetype data.
+    /// </summary>
     public class FighterPartitionKeysConfig
     {
+        /// <summary>Base Fighter partition.</summary>
         public string Base { get; set; }
+        /// <summary>Champion archetype partition.</summary>
         public string Champion { get; set; }
+        /// <summary>Battle Master archetype partition.</summary>
         public string BattleMaster { get; set; }
         public string ArcaneArcher { get; set; }
         public string Banneret { get; set; }

--- a/CloudDragon/Models/Condition.cs
+++ b/CloudDragon/Models/Condition.cs
@@ -1,9 +1,17 @@
 namespace CloudDragon.Models
 {
+    /// <summary>
+    /// Represents a status condition that can affect a combatant.
+    /// </summary>
     public class Condition
     {
+        /// <summary>Name of the condition.</summary>
         public string Name { get; set; }
+
+        /// <summary>Description of the effect.</summary>
         public string Effect { get; set; }
+
+        /// <summary>Whether the condition ends automatically at turn end.</summary>
         public bool EndsOnTurnEnd { get; set; }
     }
 }

--- a/CloudDragon/Models/Item.cs
+++ b/CloudDragon/Models/Item.cs
@@ -1,11 +1,23 @@
 namespace CloudDragon.Models
 {
+    /// <summary>
+    /// Basic representation of an inventory item.
+    /// </summary>
     public class Item
     {
+        /// <summary>Name of the item.</summary>
         public string Name { get; set; }
-        public string Type { get; set; } // Weapon, Armor, Potion
+
+        /// <summary>Item category (e.g. Weapon, Armor, Potion).</summary>
+        public string Type { get; set; }
+
+        /// <summary>Weight in pounds.</summary>
         public float Weight { get; set; }
+
+        /// <summary>Rarity classification.</summary>
         public string Rarity { get; set; }
+
+        /// <summary>Text description.</summary>
         public string Description { get; set; }
     }
 }

--- a/CloudDragon/Models/ModelContext/ILlmService.cs
+++ b/CloudDragon/Models/ModelContext/ILlmService.cs
@@ -2,8 +2,16 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.Models.ModelContext
 {
+    /// <summary>
+    /// Abstraction for a language model service used to generate text.
+    /// </summary>
     public interface ILlmService
     {
+        /// <summary>
+        /// Generates text based on the supplied prompt.
+        /// </summary>
+        /// <param name="prompt">Prompt describing the desired output.</param>
+        /// <returns>Generated text.</returns>
         Task<string> GenerateAsync(string prompt);
     }
 }

--- a/CloudDragon/Models/ModelContext/McpPromptBuilder.cs
+++ b/CloudDragon/Models/ModelContext/McpPromptBuilder.cs
@@ -6,8 +6,16 @@ using CloudDragonLib.Models;
 
 namespace CloudDragon.Models.ModelContext
 {
+    /// <summary>
+    /// Builds prompt strings for use with the language model service.
+    /// </summary>
     public class McpPromptBuilder
     {
+        /// <summary>
+        /// Creates a prompt describing the supplied model context.
+        /// </summary>
+        /// <param name="model">Model object decorated with context attributes.</param>
+        /// <returns>The assembled prompt.</returns>
         public string BuildPrompt(object model)
         {
             var type = model.GetType();
@@ -31,6 +39,11 @@ namespace CloudDragon.Models.ModelContext
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Generates a short flavor quote prompt for the given character.
+        /// </summary>
+        /// <param name="character">Character providing context.</param>
+        /// <returns>Prompt string.</returns>
         public string BuildFlavorQuotePrompt(Character character)
         {
             return
@@ -43,7 +56,6 @@ namespace CloudDragon.Models.ModelContext
                 Personality: {character.Personality}
 
             Limit to 30 words. Style it like fantasy card flavor text — poetic, cryptic, or heroic, as in Magic: The Gathering or Cardfight!! Vanguard.";
-    }
-
+        }
     }
 }

--- a/CloudDragon/Models/ModelContext/MockLlmService.cs
+++ b/CloudDragon/Models/ModelContext/MockLlmService.cs
@@ -2,8 +2,12 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.Models.ModelContext
 {
+    /// <summary>
+    /// Simple mock implementation of <see cref="ILlmService"/> for testing.
+    /// </summary>
     public class MockLlmService : ILlmService
     {
+        /// <inheritdoc />
         public Task<string> GenerateAsync(string prompt)
         {
             // Simple mock: just echoes the prompt back with a pretend "backstory".

--- a/CloudDragon/Point_Buy.cs
+++ b/CloudDragon/Point_Buy.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace CloudDragon
 {
+    /// <summary>
+    /// Implements a simple 27 point buy system for ability scores.
+    /// </summary>
     internal class Point_Buyer
     {
         private const int StartingStatPoints = 27;
@@ -21,9 +24,19 @@ namespace CloudDragon
             { 14, 7 },
             { 15, 9 }
         };
+        /// <summary>
+        /// Current ability scores after purchases.
+        /// </summary>
         public Dictionary<string, int> AbilityScores { get; private set; }
+
+        /// <summary>
+        /// Points remaining to spend.
+        /// </summary>
         public int RemainingPoints { get; private set; }
 
+        /// <summary>
+        /// Initializes a new point buy calculator with default scores.
+        /// </summary>
         public Point_Buyer()
         {
             AbilityScores = new Dictionary<string, int>
@@ -38,6 +51,12 @@ namespace CloudDragon
             RemainingPoints = StartingStatPoints;
         }
 
+        /// <summary>
+        /// Attempts to purchase an ability score at the specified value.
+        /// </summary>
+        /// <param name="abilityName">Ability name.</param>
+        /// <param name="score">Desired score.</param>
+        /// <returns>True if the purchase succeeded.</returns>
         public bool SetAbilityScore(string abilityName, int score)
         {
             if (!AbilityScores.ContainsKey(abilityName))
@@ -63,6 +82,9 @@ namespace CloudDragon
             return true;
         }
 
+        /// <summary>
+        /// Returns a summary of the current ability scores.
+        /// </summary>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/CloudDragon/Program.cs
+++ b/CloudDragon/Program.cs
@@ -13,8 +13,15 @@ using System.Collections.Generic;
 
 namespace CloudDragon
 {
+    /// <summary>
+    /// Console entry point for interacting with the Cloud Dragon sample data.
+    /// </summary>
     public partial class Program
     {
+        /// <summary>
+        /// Runs the interactive character creation workflow.
+        /// </summary>
+        /// <param name="args">Command line arguments.</param>
         private static async Task Main(string[] args)
         {
             Env.Load();
@@ -111,12 +118,23 @@ namespace CloudDragon
             await RetrieveAndDisplayItemAsync(cosmosLoader, configuration, "Characters", character.Id);
         }
 
+        /// <summary>
+        /// Displays a prompt and reads user input from the console.
+        /// </summary>
+        /// <param name="message">Prompt text to display.</param>
         private static string Prompt(string message)
         {
             Console.Write(message);
             return Console.ReadLine();
         }
 
+        /// <summary>
+        /// Fetches an item from Cosmos DB and writes it to the console.
+        /// </summary>
+        /// <param name="cosmosLoader">Loader instance.</param>
+        /// <param name="config">Application configuration.</param>
+        /// <param name="containerName">Name of the container.</param>
+        /// <param name="itemKey">Key identifying the item.</param>
         private static async Task RetrieveAndDisplayItemAsync(Cosmos_Loader cosmosLoader, IConfiguration config, string containerName, string itemKey)
         {
             var containerConfig = config.GetSection($"CosmosDb:Containers:{containerName}");

--- a/CloudDragon/WeaponsItemIdsConfig.cs
+++ b/CloudDragon/WeaponsItemIdsConfig.cs
@@ -6,15 +6,26 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.ItemIds
 {
+    /// <summary>
+    /// Item identifiers for different weapon categories.
+    /// </summary>
     public class WeaponsItemIdsConfig
     {
+        /// <summary>Martial melee weapons id.</summary>
         public string MartialMelee { get; set; }
+        /// <summary>Martial ranged weapons id.</summary>
         public string RangedMartial { get; set; }
+        /// <summary>Simple melee weapons id.</summary>
         public string SimpleMelee { get; set; }
+        /// <summary>Simple ranged weapons id.</summary>
         public string SimpleRanged { get; set; }
+        /// <summary>Renaissance firearms id.</summary>
         public string RenaissanceFirearms { get; set; }
+        /// <summary>Modern firearms id.</summary>
         public string ModernFirearms { get; set; }
+        /// <summary>Futuristic firearms id.</summary>
         public string FuturisticFirearms { get; set; }
+        /// <summary>Explosives id.</summary>
         public string Explosives { get; set; }
     }
 }

--- a/CloudDragon/WeaponsPartitionKeysConfig.cs
+++ b/CloudDragon/WeaponsPartitionKeysConfig.cs
@@ -6,15 +6,26 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.PartitionKeys
 {
+    /// <summary>
+    /// Partition key names for weapon documents.
+    /// </summary>
     public class WeaponsPartitionKeysConfig
     {
+        /// <summary>Martial melee weapons partition.</summary>
         public string MartialMelee { get; set; }
+        /// <summary>Martial ranged weapons partition.</summary>
         public string RangedMartial { get; set; }
+        /// <summary>Simple melee weapons partition.</summary>
         public string SimpleMelee { get; set; }
+        /// <summary>Simple ranged weapons partition.</summary>
         public string SimpleRanged { get; set; }
+        /// <summary>Renaissance firearms partition.</summary>
         public string RenaissanceFirearms { get; set; }
+        /// <summary>Modern firearms partition.</summary>
         public string ModernFirearms { get; set; }
+        /// <summary>Futuristic firearms partition.</summary>
         public string FuturisticFirearms { get; set; }
+        /// <summary>Explosives partition.</summary>
         public string Explosives { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add XML docs to numerous item identifier classes
- document corresponding partition key config classes for weapons and classes

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554ff64024832a9b6f2aaac2b0b2e9