### PR TITLE
Expand XML docs for character and combat APIs

### DIFF
--- a/CloudDragon/CloudDragonApi/Functions/Character/CastSpellFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CastSpellFunction.cs
@@ -13,6 +13,9 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Azure Function responsible for casting spells from a character sheet.
+    /// </summary>
     public class CastSpellFunction
     {
         private readonly CosmosClient _cosmosClient;
@@ -24,6 +27,13 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             _cosmosClient = cosmosClient;
         }
 
+        /// <summary>
+        /// Casts a spell for the specified character.
+        /// </summary>
+        /// <param name="req">HTTP request containing the spell info.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="logger">Function logger.</param>
+        /// <returns>Result with cast confirmation.</returns>
         [FunctionName("CastSpell")]
         public async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/cast-spell")] HttpRequest req,
@@ -75,6 +85,12 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
             return new OkObjectResult(new { success = true, message = $"Casted {input.Spell} (Level {input.Level})" });
         }
 
+        /// <summary>
+        /// Retrieves the character document from Cosmos DB.
+        /// </summary>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="container">Cosmos DB container.</param>
+        /// <returns>The character or <c>null</c> if not found.</returns>
         private async Task<CharacterModel?> GetCharacterAsync(string id, Container container)
         {
             try
@@ -89,9 +105,15 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
         }
     }
 
+    /// <summary>
+    /// Payload describing the spell to cast and at what level.
+    /// </summary>
     public class SpellCastInput
     {
+        /// <summary>Name of the spell being cast.</summary>
         public string Spell { get; set; }
+
+        /// <summary>Slot level used to cast the spell.</summary>
         public int Level { get; set; }
     }
 }

--- a/CloudDragon/CloudDragonApi/Functions/Character/Character.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Character.cs
@@ -5,6 +5,9 @@ using CloudDragon.Models.ModelContext;
 
 namespace CloudDragonLib.Models
 {
+    /// <summary>
+    /// Primary representation of a player character.
+    /// </summary>
     [ModelContext]
     public class Character
     {

--- a/CloudDragon/CloudDragonApi/Functions/Character/ClassSystemService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/ClassSystemService.cs
@@ -7,6 +7,9 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Provides helper methods for assigning and validating character classes.
+    /// </summary>
     public static class ClassSystemService
     {
         private static readonly Dictionary<string, int> SubclassUnlockLevels = new()
@@ -26,6 +29,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             { "artificer", 3 }
         };
 
+        /// <summary>
+        /// Assigns a primary class to the character and initializes class levels.
+        /// </summary>
+        /// <param name="character">Character to update.</param>
+        /// <param name="className">Name of the class to assign.</param>
         public static void AssignClass(CharacterModel character, string className)
         {
             if (string.IsNullOrWhiteSpace(className))
@@ -36,6 +44,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             character.Classes[className] = 1; // Start at level 1
         }
 
+        /// <summary>
+        /// Assigns a subclass to the character if allowed by level.
+        /// </summary>
+        /// <param name="character">Character to modify.</param>
+        /// <param name="subclassName">Subclass name.</param>
         public static void AssignSubclass(CharacterModel character, string subclassName)
         {
             if (string.IsNullOrWhiteSpace(subclassName))
@@ -57,6 +70,12 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             character.Subclasses[primaryClass] = subclassName;
         }
 
+        /// <summary>
+        /// Checks if the character can multiclass into the specified class.
+        /// </summary>
+        /// <param name="character">Character performing the multiclass.</param>
+        /// <param name="newClass">Class to add.</param>
+        /// <returns><c>true</c> if allowed; otherwise <c>false</c>.</returns>
         public static bool ValidateMulticlass(CharacterModel character, string newClass)
         {
             if (character.Classes.ContainsKey(newClass.ToLower()))
@@ -65,6 +84,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return true;
         }
 
+        /// <summary>
+        /// Gets the level at which a class selects a subclass.
+        /// </summary>
+        /// <param name="className">Class name.</param>
+        /// <returns>Level number when subclasses become available.</returns>
         private static int GetSubclassUnlockLevel(string className)
         {
             if (string.IsNullOrWhiteSpace(className))

--- a/CloudDragon/CloudDragonApi/Functions/Character/CombatActionService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CombatActionService.cs
@@ -5,10 +5,20 @@ using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Utility methods for resolving basic combat actions.
+    /// </summary>
     public static class CombatActionService
     {
         private static readonly Random rng = Random.Shared;
 
+        /// <summary>
+        /// Performs an attack roll against a defender.
+        /// </summary>
+        /// <param name="attacker">The attacking combatant.</param>
+        /// <param name="defender">The target combatant.</param>
+        /// <param name="attackModifier">Attack bonus to apply.</param>
+        /// <returns>Tuple describing hit result and roll totals.</returns>
         public static (bool hit, int roll, int total) ResolveAttackRoll(Combatant attacker, Combatant defender, int attackModifier = 0)
         {
             int roll = rng.Next(1, 21); // d20
@@ -17,6 +27,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return (hit, roll, total);
         }
 
+        /// <summary>
+        /// Applies a combat condition if not already present.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
+        /// <param name="condition">Condition name.</param>
         public static void ApplyCondition(Combatant combatant, string condition)
         {
             if (combatant == null || string.IsNullOrEmpty(condition))
@@ -28,6 +43,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
                 combatant.Conditions.Add(condition);
         }
 
+        /// <summary>
+        /// Removes a specific condition from the combatant.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
+        /// <param name="condition">Condition to remove.</param>
         public static void RemoveCondition(Combatant combatant, string condition)
         {
             if (combatant?.Conditions == null)
@@ -36,6 +56,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             combatant.Conditions.Remove(condition);
         }
 
+        /// <summary>
+        /// Applies a cover AC bonus and annotates the condition.
+        /// </summary>
+        /// <param name="combatant">Combatant receiving cover.</param>
+        /// <param name="coverType">Type of cover (half or three-quarters).</param>
         public static void ApplyCoverBonus(Combatant combatant, string coverType)
         {
             if (combatant == null || string.IsNullOrWhiteSpace(coverType))
@@ -52,12 +77,21 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             ApplyCondition(combatant, $"Cover ({coverType})");
         }
 
+        /// <summary>
+        /// Marks the combatant as dodging until their next turn.
+        /// </summary>
+        /// <param name="combatant">Combatant taking the dodge action.</param>
         public static void HandleDodge(Combatant combatant)
         {
             ApplyCondition(combatant, "Dodging");
         }
 
-       public static void ApplyDamage(Combatant target, int damage)
+        /// <summary>
+        /// Applies damage to the target and handles unconsciousness.
+        /// </summary>
+        /// <param name="target">Combatant taking damage.</param>
+        /// <param name="damage">Amount of hit point damage.</param>
+        public static void ApplyDamage(Combatant target, int damage)
         {
             target.HP -= damage;
             target.Conditions ??= new List<string>();

--- a/CloudDragon/CloudDragonApi/Functions/Character/CombatConditionsService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/CombatConditionsService.cs
@@ -4,8 +4,16 @@ using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Helper methods for managing combat conditions on characters.
+    /// </summary>
     public static class CombatConditionsService
     {
+        /// <summary>
+        /// Adds a condition to the combatant if not already present.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
+        /// <param name="condition">Condition name.</param>
         public static void ApplyCondition(Combatant combatant, string condition)
         {
             if (combatant == null || string.IsNullOrWhiteSpace(condition))
@@ -17,6 +25,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
                 combatant.Conditions.Add(condition);
         }
 
+        /// <summary>
+        /// Removes the specified condition from the combatant.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
+        /// <param name="condition">Condition to remove.</param>
         public static void RemoveCondition(Combatant combatant, string condition)
         {
             if (combatant?.Conditions == null)
@@ -25,11 +38,21 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             combatant.Conditions.Remove(condition);
         }
 
+        /// <summary>
+        /// Checks if the combatant currently has the given condition.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
+        /// <param name="condition">Condition to check.</param>
+        /// <returns><c>true</c> if present; otherwise <c>false</c>.</returns>
         public static bool HasCondition(Combatant combatant, string condition)
         {
             return combatant?.Conditions != null && combatant.Conditions.Contains(condition);
         }
 
+        /// <summary>
+        /// Removes all conditions from the combatant.
+        /// </summary>
+        /// <param name="combatant">Target combatant.</param>
         public static void ClearAllConditions(Combatant combatant)
         {
             combatant?.Conditions?.Clear();

--- a/CloudDragon/CloudDragonApi/Functions/Character/EquipItem.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/EquipItem.cs
@@ -15,8 +15,20 @@ using CloudDragon.Equipment;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Equips an item from a character's inventory.
+    /// </summary>
     public static class EquipItem
     {
+        /// <summary>
+        /// HTTP endpoint used to equip an item on a character.
+        /// </summary>
+        /// <param name="req">Request containing the item id.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character document from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding to persist changes.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result describing success or failure.</returns>
         [FunctionName("EquipItem")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/equip")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/LevelUpOptionsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/LevelUpOptionsFunction.cs
@@ -16,8 +16,18 @@ using CloudDragon.CloudDragonApi.Functions.Character.Services;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Provides level-up option information for a character document.
+    /// </summary>
     public static class LevelUpOptionsFunction
     {
+        /// <summary>
+        /// Generates available level-up choices for the specified character.
+        /// </summary>
+        /// <param name="req">HTTP request containing the character id.</param>
+        /// <param name="character">Character data loaded from Cosmos DB.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>A summary of level-up options.</returns>
         [FunctionName("GetLevelUpOptions")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/level-up-options")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/LongRestFunction.cs
@@ -11,8 +11,20 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Restores spell slots and clears cast spells for a character.
+    /// </summary>
     public static class LongRestFunction
     {
+        /// <summary>
+        /// Azure Function HTTP trigger to process a long rest event.
+        /// </summary>
+        /// <param name="req">Incoming request.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character document loaded from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding for persisting changes.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>A result indicating success.</returns>
         [FunctionName("LongRest")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/long-rest")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/MockData.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/MockData.cs
@@ -10,8 +10,18 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Development helper for loading a few sample characters.
+    /// </summary>
     public static class LoadMockCharactersFunction
     {
+        /// <summary>
+        /// Inserts predefined mock characters into the database.
+        /// </summary>
+        /// <param name="req">Triggering HTTP request.</param>
+        /// <param name="characterOut">Output binding to Cosmos DB.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result containing number of characters created.</returns>
         [FunctionName("LoadMockCharacters")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "dev/mock-characters")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/PointBuyFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/PointBuyFunction.cs
@@ -12,13 +12,26 @@ using CloudDragonLib;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Input payload for the point buy character stat generator.
+    /// </summary>
     public class PointBuyInput
     {
+        /// <summary>Requested ability scores.</summary>
         public Dictionary<string, int> Stats { get; set; }
     }
 
+    /// <summary>
+    /// Azure Function that calculates ability scores using the point buy system.
+    /// </summary>
     public static class PointBuyFunction
     {
+        /// <summary>
+        /// Executes the point buy calculation for the provided stats.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result with generated ability scores or an error.</returns>
         [FunctionName("PointBuy")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "point-buy")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/PrepareSpellsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/PrepareSpellsFunction.cs
@@ -13,8 +13,20 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Updates a character's list of prepared spells.
+    /// </summary>
     public static class PrepareSpellsFunction
     {
+        /// <summary>
+        /// HTTP POST endpoint to set the prepared spells for a character.
+        /// </summary>
+        /// <param name="req">Request containing spells to prepare.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character document from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding to persist the change.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result listing the prepared spells.</returns>
         [FunctionName("PrepareSpells")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/prepare-spells")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/RemoveItemFromInventory.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/RemoveItemFromInventory.cs
@@ -14,8 +14,20 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Removes an item from a character's inventory.
+    /// </summary>
     public static class RemoveItemFromInventory
     {
+        /// <summary>
+        /// HTTP endpoint used to delete an item from inventory.
+        /// </summary>
+        /// <param name="req">Request containing the item id.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character document loaded from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding to persist the removal.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result with removal confirmation.</returns>
         [FunctionName("RemoveItemFromInventory")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/inventory/remove")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/SaveCharacter.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/SaveCharacter.cs
@@ -10,12 +10,21 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragonLib.Models;
 using CharacterModel = CloudDragonLib.Models.Character;
-using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Creates and persists a new character document.
+    /// </summary>
     public static class SaveCharacterFunction
     {
+    /// <summary>
+    /// HTTP POST endpoint to save a character to Cosmos DB.
+    /// </summary>
+    /// <param name="req">Request containing the character data.</param>
+    /// <param name="characterOut">Output binding for persisted character.</param>
+    /// <param name="log">Function logger.</param>
+    /// <returns>Result containing the new character id.</returns>
     [FunctionName("SaveCharacter")]
     public static async Task<IActionResult> SaveCharacter(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character")] HttpRequest req,
@@ -58,6 +67,10 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
         }
     }
 
+    /// <summary>
+    /// Initializes a basic set of spell slots based on class and level.
+    /// </summary>
+    /// <param name="character">Character to initialize.</param>
     private static void InitializeSpellSlots(CharacterModel character)
     {
         var fullCasters = new List<string> { "wizard", "cleric", "druid", "bard", "sorcerer", "warlock" };

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/CombatRollService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/CombatRollService.cs
@@ -5,10 +5,17 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Provides dice rolling helpers for combat scenarios.
+    /// </summary>
     public static class CombatRollService
     {
         private static readonly Random rng = Random.Shared;
 
+        /// <summary>
+        /// Rolls a d20 and logs the result.
+        /// </summary>
+        /// <returns>Random value between 1 and 20.</returns>
         public static int RollD20()
         {
             int roll = rng.Next(1, 21);
@@ -16,6 +23,13 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return roll;
         }
 
+        /// <summary>
+        /// Performs a saving throw roll for the specified ability.
+        /// </summary>
+        /// <param name="target">Character attempting the save.</param>
+        /// <param name="ability">Ability name used for the save.</param>
+        /// <param name="dc">Difficulty class to beat.</param>
+        /// <returns>Tuple containing roll, total and success flag.</returns>
         public static (int roll, int total, bool success) RollSavingThrow(CharacterModel target, string ability, int dc)
         {
             target.Stats ??= new Dictionary<string, int>();
@@ -32,6 +46,13 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return (roll, total, success);
         }
 
+        /// <summary>
+        /// Performs an attack roll against a target AC.
+        /// </summary>
+        /// <param name="attacker">Attacking character.</param>
+        /// <param name="targetAC">Armor class of the target.</param>
+        /// <param name="attackModifier">Attack bonus to include.</param>
+        /// <returns>Tuple containing roll, total and hit flag.</returns>
         public static (int roll, int total, bool hit) RollAttack(CharacterModel attacker, int targetAC, int attackModifier = 0)
         {
             int roll = RollD20();
@@ -42,6 +63,11 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
             return (roll, total, hit);
         }
 
+        /// <summary>
+        /// Rolls damage using standard dice notation (e.g. 2d6).
+        /// </summary>
+        /// <param name="damageDice">Damage dice expression.</param>
+        /// <returns>Total damage rolled.</returns>
         public static int RollDamage(string damageDice)
         {
             if (string.IsNullOrWhiteSpace(damageDice))

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/LevelUpService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/LevelUpService.cs
@@ -15,8 +15,16 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Business logic helpers for leveling up characters.
+    /// </summary>
     public static class LevelUpService
     {
+        /// <summary>
+        /// Determines whether a character becomes eligible to choose a subclass.
+        /// </summary>
+        /// <param name="character">Character being leveled.</param>
+        /// <returns><c>true</c> if a subclass can be chosen.</returns>
         public static bool CheckSubclassUnlock(CharacterModel character)
         {
             if (character == null || string.IsNullOrWhiteSpace(character.Class))
@@ -33,11 +41,22 @@ namespace CloudDragon.CloudDragonApi.Functions.Character.Services
     }
 }
 
-// 2. Create POST /character/{id}/level-up function
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Azure Function for incrementing a character's level.
+    /// </summary>
     public static class CharacterLevelUpFunction
     {
+        /// <summary>
+        /// Increments the level of the specified character.
+        /// </summary>
+        /// <param name="req">HTTP request triggering the level up.</param>
+        /// <param name="character">Character document from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding for saving changes.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result containing new level information.</returns>
         [FunctionName("LevelUpCharacter")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/level-up")] HttpRequest req,
@@ -72,11 +91,22 @@ namespace CloudDragon.CloudDragonApi.Functions.Character
     }
 }
 
-// 3. Build POST /character/{id}/subclass function
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Assigns a subclass to an existing character.
+    /// </summary>
     public static class AssignSubclassFunction
     {
+        /// <summary>
+        /// Updates the character's subclass if valid.
+        /// </summary>
+        /// <param name="req">HTTP request containing the subclass.</param>
+        /// <param name="character">Character document to update.</param>
+        /// <param name="characterOut">Output binding for saving.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Operation result.</returns>
         [FunctionName("AssignSubclass")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/subclass")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/MulticlassValidationService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/MulticlassValidationService.cs
@@ -5,8 +5,16 @@ using CharacterModel = CloudDragonLib.Models.Character;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character.Services
 {
+    /// <summary>
+    /// Provides validation helpers for characters with multiple classes.
+    /// </summary>
     public static class MulticlassValidationService
     {
+        /// <summary>
+        /// Validates the character's multiclass configuration.
+        /// </summary>
+        /// <param name="character">Character to inspect.</param>
+        /// <returns>A list of validation error messages.</returns>
         public static List<string> ValidateMulticlass(CharacterModel character)
         {
             var errors = new List<string>();

--- a/CloudDragon/CloudDragonApi/Functions/Character/Services/SubclassService.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/Services/SubclassService.cs
@@ -10,8 +10,19 @@ using Newtonsoft.Json;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Utility endpoints for working with character subclasses.
+    /// </summary>
     public static class SubclassService
     {
+        /// <summary>
+        /// Retrieves available subclasses for the specified class.
+        /// </summary>
+        /// <param name="req">Incoming request.</param>
+        /// <param name="className">Class name being queried.</param>
+        /// <param name="allEntries">Cosmos DB records for that class.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>List of subclasses or an error response.</returns>
         [FunctionName("GetAvailableSubclasses")]
         public static async Task<IActionResult> GetAvailableSubclasses(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "subclasses/{className}")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Character/UnequipItem.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Character/UnequipItem.cs
@@ -14,8 +14,20 @@ using CloudDragon.Equipment;
 
 namespace CloudDragon.CloudDragonApi.Functions.Character
 {
+    /// <summary>
+    /// Removes an equipped item from the specified slot on a character.
+    /// </summary>
     public static class UnequipItem
     {
+        /// <summary>
+        /// HTTP entry point for unequipping an item.
+        /// </summary>
+        /// <param name="req">Request containing slot information.</param>
+        /// <param name="id">Character identifier.</param>
+        /// <param name="character">Character document from Cosmos DB.</param>
+        /// <param name="characterOut">Output binding to persist the update.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result containing success status.</returns>
         [FunctionName("UnequipItem")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "character/{id}/unequip")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/AdvanceTurn.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/AdvanceTurn.cs
@@ -10,7 +10,6 @@ using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;
@@ -79,9 +78,5 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
                 round = session.Round
             });
         }
-
-        // The CreateCombatSession and EndCombatSession functions were moved to
-        // dedicated files.  Keeping only AdvanceTurn here avoids duplicate
-        // FunctionName attributes which caused runtime indexing errors.
     }
 }

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ApplyConditionFunction.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragon.CloudDragonApi.Functions.Character.Services;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;

--- a/CloudDragon/CloudDragonApi/Functions/Combat/ClearConditionsFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/ClearConditionsFunction.cs
@@ -7,15 +7,27 @@ using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using CloudDragon.CloudDragonApi.Functions.Character.Services;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Removes all combat conditions from a combatant within a session.
+    /// </summary>
     public static class ClearConditionsFunction
     {
+        /// <summary>
+        /// HTTP trigger that clears every condition from a combatant.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request.</param>
+        /// <param name="sessionId">Identifier of the combat session.</param>
+        /// <param name="combatantId">Combatant id to clear conditions for.</param>
+        /// <param name="session">Loaded combat session document.</param>
+        /// <param name="sessionOut">Output binding for persisting updates.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result object describing success or failure.</returns>
         [FunctionName("ClearConditions")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = "combat/{sessionId}/combatant/{combatantId}/clear-conditions")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/CombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/CombatSession.cs
@@ -9,7 +9,6 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat

--- a/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/CreateCombatSession.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using Newtonsoft.Json;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat

--- a/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/EndCombatSession.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using CloudDragon.CloudDragonApi;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using System.Linq;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;

--- a/CloudDragon/CloudDragonApi/Functions/Combat/GetCombatState.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/GetCombatState.cs
@@ -4,7 +4,6 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using System.Linq;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
@@ -12,13 +11,24 @@ using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
-public static class GetCombatStateFunction
-{
-    [FunctionName("GetCombatState")]
-    public static IActionResult Run(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "combat/{id}")] HttpRequest req,
-        [CosmosDB(
-            DatabaseName = "CloudDragonDB",
+    /// <summary>
+    /// Retrieves the full combat state for a given session.
+    /// </summary>
+    public static class GetCombatStateFunction
+    {
+        /// <summary>
+        /// HTTP GET endpoint to fetch combat session details.
+        /// </summary>
+        /// <param name="req">The incoming HTTP request.</param>
+        /// <param name="session">Session loaded from Cosmos DB.</param>
+        /// <param name="id">Session identifier.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Action result with the combat state.</returns>
+        [FunctionName("GetCombatState")]
+        public static IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "combat/{id}")] HttpRequest req,
+            [CosmosDB(
+                DatabaseName = "CloudDragonDB",
             ContainerName = "CombatSessions",
             ConnectionStringSetting = "CosmosDBConnection",
             Id = "{id}",
@@ -46,7 +56,6 @@ public static class GetCombatStateFunction
             currentTurn = current?.Name ?? "No active combatant",
             round = session.Round
         });
-    } 
+    }
 }
 }
-// This function retrieves the current state of a combat session in a D&D game.

--- a/CloudDragon/CloudDragonApi/Functions/Combat/GetConditions.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/GetConditions.cs
@@ -9,8 +9,17 @@ using CloudDragon.CloudDragonApi.Utils;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Returns a list of common combat conditions.
+    /// </summary>
     public static class GetConditionsFunction
     {
+        /// <summary>
+        /// HTTP trigger that returns available combat conditions.
+        /// </summary>
+        /// <param name="req">The incoming HTTP request.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Collection of conditions.</returns>
         [FunctionName("GetConditions")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "conditions")] HttpRequest req,
@@ -45,10 +54,16 @@ namespace CloudDragon.CloudDragonApi.Functions.Combat
         }
     }
 
+    /// <summary>
+    /// Representation of a combat condition and its basic effects.
+    /// </summary>
     public class Condition
     {
+        /// <summary>Name of the condition.</summary>
         public string Name { get; set; }
+        /// <summary>Short description of the effect.</summary>
         public string Effect { get; set; }
+        /// <summary>Whether the condition automatically ends at turn end.</summary>
         public bool EndsOnTurnEnd { get; set; }
     }
 }

--- a/CloudDragon/CloudDragonApi/Functions/Combat/GetInitiativeOrder.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/GetInitiativeOrder.cs
@@ -5,15 +5,25 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Retrieves the initiative order for a combat session.
+    /// </summary>
     public static class GetInitiativeOrder
     {
+        /// <summary>
+        /// HTTP GET endpoint returning combatants sorted by initiative.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request.</param>
+        /// <param name="sessionId">Combat session identifier.</param>
+        /// <param name="session">Session document from Cosmos DB.</param>
+        /// <param name="log">Function logger.</param>
+        /// <returns>Result with the initiative order list.</returns>
         [FunctionName("GetInitiativeOrder")]
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Function, "get", Route = "combat/{sessionId}/initiative")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RemoveConditionFunction.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragon.CloudDragonApi.Functions.Character.Services;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;

--- a/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/RollInitiative.cs
@@ -8,7 +8,6 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using CloudDragon.CloudDragonApi.Functions.Combat; // Make sure CombatSession is from the correct namespace
 using Newtonsoft.Json;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;

--- a/CloudDragon/CloudDragonApi/Functions/Combat/UpdateCombatant.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/UpdateCombatant.cs
@@ -9,15 +9,27 @@ using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;
 
 namespace CloudDragon.CloudDragonApi.Functions.Combat
 {
+    /// <summary>
+    /// Updates an existing combatant within a combat session document.
+    /// </summary>
     public static class UpdateCombatantFunction
     {
+        /// <summary>
+        /// Handles HTTP PATCH requests to update a combatant's data.
+        /// </summary>
+        /// <param name="req">Incoming HTTP request containing updated values.</param>
+        /// <param name="session">Existing combat session loaded from Cosmos DB.</param>
+        /// <param name="sessionOut">Output binding used to persist the session.</param>
+        /// <param name="sessionId">Identifier for the combat session.</param>
+        /// <param name="name">Combatant name to update.</param>
+        /// <param name="log">Function logger instance.</param>
+        /// <returns>Result detailing success or failure of the update.</returns>
         [FunctionName("UpdateCombatant")]
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Function, "patch", Route = "combat/{sessionId}/combatant/{name}")] HttpRequest req,

--- a/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
+++ b/CloudDragon/CloudDragonApi/Functions/Combat/UseCombatAction.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using CloudDragon.CloudDragonApi.Functions.Character.Services;
-using CloudDragon.CloudDragonApi.Functions.Combat;
 using CloudDragon.CloudDragonApi;
 using CloudDragon.CloudDragonApi.Utils;
 using CloudDragon.Models;

--- a/CloudDragon/DruidPartitionKeysConfig.cs
+++ b/CloudDragon/DruidPartitionKeysConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,25 +6,46 @@ using System.Threading.Tasks;
 
 namespace CloudDragon.PartitionKeys
 {
+    /// <summary>
+    /// Defines Cosmos DB partition key names for Druid class data.
+    /// </summary>
     public class DruidPartitionKeysConfig
     {
+        /// <summary>Base Druid class partition key.</summary>
         public string Base { get; set; }
+        /// <summary>Circle of the Land partition key.</summary>
         public string CircleOfTheLand { get; set; }
+        /// <summary>Circle of the Moon partition key.</summary>
         public string CircleOfTheMoon { get; set; }
+        /// <summary>Circle of Dreams partition key.</summary>
         public string CircleOfDreams { get; set; }
+        /// <summary>Circle of the Shepherd partition key.</summary>
         public string CircleOfShepherd { get; set; }
+        /// <summary>Circle of Spores partition key.</summary>
         public string CircleOfSpores { get; set; }
+        /// <summary>Circle of Stars partition key.</summary>
         public string CircleOfStars { get; set; }
+        /// <summary>Circle of Wildfire partition key.</summary>
         public string CircleOfWildfire { get; set; }
+        /// <summary>Container for Druid cantrips.</summary>
         public string Cantrips { get; set; }
+        /// <summary>Container for 1st level spells.</summary>
         public string Level1Spells { get; set; }
+        /// <summary>Container for 2nd level spells.</summary>
         public string Level2Spells { get; set; }
+        /// <summary>Container for 3rd level spells.</summary>
         public string Level3Spells { get; set; }
+        /// <summary>Container for 4th level spells.</summary>
         public string Level4Spells { get; set; }
+        /// <summary>Container for 5th level spells.</summary>
         public string Level5Spells { get; set; }
+        /// <summary>Container for 6th level spells.</summary>
         public string Level6Spells { get; set; }
+        /// <summary>Container for 7th level spells.</summary>
         public string Level7Spells { get; set; }
+        /// <summary>Container for 8th level spells.</summary>
         public string Level8Spells { get; set; }
+        /// <summary>Container for 9th level spells.</summary>
         public string Level9Spells { get; set; }
     }
 

--- a/CloudDragon/Models/Combatant.cs
+++ b/CloudDragon/Models/Combatant.cs
@@ -5,16 +5,33 @@ using Newtonsoft.Json;
 
 namespace CloudDragon.Models
 {
+    /// <summary>
+    /// Participant in a combat encounter such as a player or monster.
+    /// </summary>
     public class Combatant
     {
+        /// <summary>
+        /// Unique identifier used as the Cosmos DB id.
+        /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        /// <summary>Name displayed for the combatant.</summary>
         public string Name { get; set; }
+
+        /// <summary>Modifier added to initiative rolls.</summary>
         public int InitiativeModifier { get; set; }
-        public int Initiative { get; set; } // Calculated when session starts
+
+        /// <summary>Result of the initiative roll for the session.</summary>
+        public int Initiative { get; set; }
+
+        /// <summary>Current hit points.</summary>
         public int HP { get; set; }
+
+        /// <summary>Armor class value.</summary>
         public int AC { get; set; }
 
+        /// <summary>Active condition names affecting this combatant.</summary>
         public List<string> Conditions { get; set; } = new();
 
         /// <summary>
@@ -27,6 +44,8 @@ namespace CloudDragon.Models
         /// (e.g. "Dexterity"). Used for initiative and other rolls.
         /// </summary>
         public Dictionary<string, int> Stats { get; set; } = new();
+
+        /// <summary>True if <see cref="HP"/> is zero or below.</summary>
         public bool IsDowned => HP <= 0;
     }
 }


### PR DESCRIPTION
## Summary
- add missing summaries for combat helper functions
- document character management endpoints and services
- clean up leftover comments and duplicate usings
- provide XML docs for spell casting payloads
- remove extraneous combat usings and add docs for the Combatant model

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f7132d10832a9aaa6598c91638fb