### PR TITLE
Fix Cosmos binding names and remove storage reference

### DIFF
--- a/CloudDragon/CloudDragon.csproj
+++ b/CloudDragon/CloudDragon.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="4.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="4.0.0" />
     <!-- Required for IAsyncCollector and other in-process bindings -->
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <!-- Packages required for legacy in-process functions -->
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />

--- a/CloudDragon/GlobalUsings.cs
+++ b/CloudDragon/GlobalUsings.cs
@@ -6,7 +6,6 @@
 global using Microsoft.Azure.WebJobs;
 global using Microsoft.Azure.WebJobs.Extensions.CosmosDB;
 global using Microsoft.Azure.WebJobs.Extensions.Http;
-global using Microsoft.Azure.WebJobs.Extensions.Storage;
 
 // ASP.NET Core primitives and logging abstractions
 global using Microsoft.AspNetCore.Mvc;


### PR DESCRIPTION
## Summary
- revert functions to use WebJobs Cosmos DB attributes (`DatabaseName`, `CollectionName`)
- remove obsolete storage extension from project and global usings

## Testing
- `dotnet test CloudDragonLib/CloudDragonLib.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585809a6ec832ab71b564ce831fb8f